### PR TITLE
Changed Start Configuration

### DIFF
--- a/valheim/valheim_bepinex/egg-valheim-bep-i-nex.json
+++ b/valheim/valheim_bepinex/egg-valheim-bep-i-nex.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2024-03-20T08:48:44+01:00",
+    "exported_at": "2024-05-08T14:03:07-05:00",
     "name": "Valheim  BepINex",
     "author": "eggs@goover.dev",
     "description": "A brutal exploration and survival game for 1-10 players, set in a procedurally-generated purgatory inspired by viking culture incl the Plugin Framework BepInEx",
@@ -18,7 +18,7 @@
     "startup": "export DOORSTOP_ENABLE=TRUE; export DOORSTOP_INVOKE_DLL_PATH=.\/BepInEx\/core\/BepInEx.Preloader.dll; export LD_LIBRARY_PATH=\".\/doorstop_libs:$LD_LIBRARY_PATH\"; export LD_PRELOAD=\"libdoorstop_x64.so:$LD_PRELOAD\"; export templdpath=$LD_LIBRARY_PATH; export LD_LIBRARY_PATH=\".\/linux64:$LD_LIBRARY_PATH\"; export SteamAppId=892970; export LD_LIBRARY_PATH=$templdpath; .\/valheim_server.x86_64 -nographics -batchmode -name \"{{SERVER_NAME}}\" -port {{SERVER_PORT}} -world \"{{WORLD}}\" -password \"{{PASSWORD}}\" -public {{PUBLIC_SERVER}} -saveinterval {{BACKUP_INTERVAL}} -backups {{BACKUP_COUNT}} -backupshort {{BACKUP_SHORTTIME}} -backuplong {{BACKUP_LONGTIME}} $( [[ {{ENABLE_CROSSPLAY}} -eq 1 ]] && echo \" -crossplay \") > >(sed -uE \"{{CONSOLE_FILTER}}\") & trap \"{{STOP}}\" 15; wait $!",
     "config": {
         "files": "{}",
-        "startup": "{\r\n    \"done\": \"DungeonDB Start\"\r\n}",
+        "startup": "{\r\n    \"done\": \"Game server connected\"\r\n}",
         "logs": "{}",
         "stop": "^C"
     },


### PR DESCRIPTION
Changed Start Configuration to more accurate represent when the server is ready for client connections.

old was "DungeonDB Start" but clients are not actually able to connect until the server says "Game server connected"

When "DungeonDB Start" appears, the server may still be generating or loading world files, and clients will not be able to connect if it is doing so. The world is done loading/generating when the message "Game server connected" appears.

# Description

Some users we confused and complaining they could not connect to their servers. This was because the server is not actually ready for client connections after "DungeonDB Start" but rather when "Game server connected" appears.
Impatient users would try to connect multiple times, but the server would ignore these attempts as it was still generating the world. Once the world is generated and the server is ready for client connections, the server displays "Game server connected" this is simply a visual thing to help with Impatient users.

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- If this is an egg update fill these out -->

* [x] You verify that the start command applied does not use a shell script
  * [x] If some script is needed then it is part of a current yolk or a PR to add one
* [x] The egg was exported from the panel