### PR TITLE
[DayZ] Fixed/Improved BattlEye RCON

### DIFF
--- a/dayz/egg-day-z.json
+++ b/dayz/egg-day-z.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2024-06-05T20:20:54-07:00",
+    "exported_at": "2024-06-13T12:52:57+07:00",
     "name": "DayZ",
     "author": "red_thirten@yahoo.com",
     "uuid": "ef7d4603-175b-4c7c-a827-516a6c19c101",
@@ -16,16 +16,16 @@
         "ghcr.io\/parkervcp\/games:dayz": "ghcr.io\/parkervcp\/games:dayz"
     },
     "file_denylist": [],
-    "startup": ".\/{{SERVER_BINARY}} -port={{SERVER_PORT}} -profiles=profiles -BEpath=battleye -config=serverDZ.cfg -mod={{CLIENT_MODS}} -serverMod={{SERVERMODS}} {{STARTUP_PARAMS}}",
+    "startup": ".\/{{SERVER_BINARY}} -port={{SERVER_PORT}} -profiles=profiles -bepath=.\/ -config=serverDZ.cfg -mod={{CLIENT_MODS}} -serverMod={{SERVERMODS}} {{STARTUP_PARAMS}}",
     "config": {
-        "files": "{\r\n    \"serverDZ.cfg\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"hostname =\": \"hostname = \\\"{{env.SERVER_HOSTNAME}}\\\";\",\r\n            \"password =\": \"password = \\\"{{env.SERVER_PASSWORD}}\\\";\",\r\n            \"passwordAdmin =\": \"passwordAdmin = \\\"{{env.ADMIN_PASSWORD}}\\\";\",\r\n            \"maxPlayers\": \"maxPlayers = {{env.MAX_PLAYERS}};\",\r\n            \"verifySignatures\": \"verifySignatures = {{env.VERIFY_SIGNATURES}};\",\r\n            \"forceSameBuild\": \"forceSameBuild = {{env.ENFORCE_BUILD}};\",\r\n            \"disableVoN\": \"disableVoN = {{env.DISABLE_VON}};\",\r\n            \"vonCodecQuality\": \"vonCodecQuality = {{env.VON_QUALITY}};\",\r\n            \"disable3rdPerson\": \"disable3rdPerson = {{env.DISABLE_THIRD}};\",\r\n            \"disableCrosshair\": \"disableCrosshair = {{env.DISABLE_CROSSHAIR}};\",\r\n            \"disablePersonalLight\": \"disablePersonalLight = {{env.DISABLE_PERSONAL_LIGHT}};\",\r\n            \"lightingConfig\": \"lightingConfig = {{env.LIGHTING_CONFIG}};\",\r\n            \"serverTimeAcceleration\": \"serverTimeAcceleration = {{env.TIME_MULT}};\",\r\n            \"serverNightTimeAcceleration\": \"serverNightTimeAcceleration = {{env.NIGHT_MULT}};\",\r\n            \"serverTimePersistent\": \"serverTimePersistent = {{env.PERSISTENT_TIME}};\",\r\n            \"steamQueryPort\": \"steamQueryPort = {{env.QUERY_PORT}};\"\r\n        }\r\n    }\r\n}",
+        "files": "{\r\n    \"serverDZ.cfg\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"hostname =\": \"hostname = \\\"{{env.SERVER_HOSTNAME}}\\\";\",\r\n            \"password =\": \"password = \\\"{{env.SERVER_PASSWORD}}\\\";\",\r\n            \"passwordAdmin =\": \"passwordAdmin = \\\"{{env.ADMIN_PASSWORD}}\\\";\",\r\n            \"maxPlayers\": \"maxPlayers = {{env.MAX_PLAYERS}};\",\r\n            \"verifySignatures\": \"verifySignatures = {{env.VERIFY_SIGNATURES}};\",\r\n            \"forceSameBuild\": \"forceSameBuild = {{env.ENFORCE_BUILD}};\",\r\n            \"disableVoN\": \"disableVoN = {{env.DISABLE_VON}};\",\r\n            \"vonCodecQuality\": \"vonCodecQuality = {{env.VON_QUALITY}};\",\r\n            \"disable3rdPerson\": \"disable3rdPerson = {{env.DISABLE_THIRD}};\",\r\n            \"disableCrosshair\": \"disableCrosshair = {{env.DISABLE_CROSSHAIR}};\",\r\n            \"disablePersonalLight\": \"disablePersonalLight = {{env.DISABLE_PERSONAL_LIGHT}};\",\r\n            \"lightingConfig\": \"lightingConfig = {{env.LIGHTING_CONFIG}};\",\r\n            \"serverTimeAcceleration\": \"serverTimeAcceleration = {{env.TIME_MULT}};\",\r\n            \"serverNightTimeAcceleration\": \"serverNightTimeAcceleration = {{env.NIGHT_MULT}};\",\r\n            \"serverTimePersistent\": \"serverTimePersistent = {{env.PERSISTENT_TIME}};\",\r\n            \"steamQueryPort\": \"steamQueryPort = {{env.QUERY_PORT}};\"\r\n        }\r\n    },\r\n    \"battleye\/beserver_x64.cfg\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"RConPort\": \"RConPort {{env.RCON_PORT}}\",\r\n            \"RConPassword\": \"RConPassword {{env.RCON_PASSWORD}}\"\r\n        }\r\n    }\r\n}",
         "startup": "{\r\n    \"done\": \"Mission read.\"\r\n}",
         "logs": "{}",
         "stop": "^C"
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/bash\r\n\r\n## File: DayZ Egg - egg-dayz.json\r\n## Author: David Wolfe (Red-Thirten)\r\n## Date: 2024\/06\/05\r\n## License: MIT License\r\n## Image to install with is 'ghcr.io\/parkervcp\/installers:debian'\r\n\r\n## Download and install SteamCMD\r\nexport HOME=\/mnt\/server\r\ncd \/tmp\r\nmkdir -p $HOME\/steamcmd $HOME\/steamapps\r\ncurl -sSL -o steamcmd.tar.gz https:\/\/steamcdn-a.akamaihd.net\/client\/installer\/steamcmd_linux.tar.gz\r\ntar -xzvf steamcmd.tar.gz -C $HOME\/steamcmd\r\ncd $HOME\/steamcmd\r\n\r\n# SteamCMD fails otherwise for some reason, even running as root.\r\n# This is changed at the end of the install process anyways.\r\nchown -R root:root \/mnt\r\n\r\n# Install\/Verify game server using SteamCMD\r\n.\/steamcmd.sh +force_install_dir $HOME \"+login \\\"${STEAM_USER}\\\" \\\"${STEAM_PASS}\\\"\" +app_update ${STEAMCMD_APPID} $( [[ -z ${STEAMCMD_BETAID} ]] || printf %s \"-beta ${STEAMCMD_BETAID}\" ) $( [[ -z ${STEAMCMD_BETAPASS} ]] || printf %s \"-betapassword ${STEAMCMD_BETAPASS}\" ) ${INSTALL_FLAGS} validate +quit\r\n\r\n# Set up 32 and 64 bit libraries\r\nmkdir -p $HOME\/.steam\/sdk{32,64}\r\ncp -v linux32\/steamclient.so $HOME\/.steam\/sdk32\/steamclient.so\r\ncp -v linux64\/steamclient.so $HOME\/.steam\/sdk64\/steamclient.so\r\n\r\n## DayZ Setup\r\ncd $HOME\r\n\r\n# Check for successful installation\r\nif [ ! -f DayZServer ] || [ ! -f serverDZ.cfg ]; then\r\n    echo -e \"\\n\\n[ERROR] SteamCMD failed to install the DayZ Dedicated Server!\"\r\n    echo -e \"\\tTry reinstalling the server again.\\n\"\r\n    exit 1\r\nfi\r\n\r\n# Add required steamQueryPort parameter to end of default serverDZ.cfg (if it's missing)\r\nif ! grep -q \"steamQueryPort\" serverDZ.cfg; then\r\n    echo -e '\\nAdding required additional parameters to end of default \"serverDZ.cfg\"...'\r\ncat >> serverDZ.cfg << EOL\r\n\r\n\r\nsteamQueryPort = 2305;\r\nEOL\r\nfi\r\n\r\necho -e \"\\nDayZ Dedicated Server successfully installed!\\n\"",
+            "script": "#!\/bin\/bash\r\n\r\n## File: DayZ Egg - egg-dayz.json\r\n## Author: David Wolfe (Red-Thirten)\r\n## Date: 2024\/06\/05\r\n## License: MIT License\r\n## Image to install with is 'ghcr.io\/parkervcp\/installers:debian'\r\n\r\n## Download and install SteamCMD\r\nexport HOME=\/mnt\/server\r\ncd \/tmp\r\nmkdir -p $HOME\/steamcmd $HOME\/steamapps\r\ncurl -sSL -o steamcmd.tar.gz https:\/\/steamcdn-a.akamaihd.net\/client\/installer\/steamcmd_linux.tar.gz\r\ntar -xzvf steamcmd.tar.gz -C $HOME\/steamcmd\r\ncd $HOME\/steamcmd\r\n\r\n# SteamCMD fails otherwise for some reason, even running as root.\r\n# This is changed at the end of the install process anyways.\r\nchown -R root:root \/mnt\r\n\r\n# Install\/Verify game server using SteamCMD\r\n.\/steamcmd.sh +force_install_dir $HOME \"+login \\\"${STEAM_USER}\\\" \\\"${STEAM_PASS}\\\"\" +app_update ${STEAMCMD_APPID} $( [[ -z ${STEAMCMD_BETAID} ]] || printf %s \"-beta ${STEAMCMD_BETAID}\" ) $( [[ -z ${STEAMCMD_BETAPASS} ]] || printf %s \"-betapassword ${STEAMCMD_BETAPASS}\" ) ${INSTALL_FLAGS} validate +quit\r\n\r\n# Set up 32 and 64 bit libraries\r\nmkdir -p $HOME\/.steam\/sdk{32,64}\r\ncp -v linux32\/steamclient.so $HOME\/.steam\/sdk32\/steamclient.so\r\ncp -v linux64\/steamclient.so $HOME\/.steam\/sdk64\/steamclient.so\r\n\r\n## DayZ Setup\r\ncd $HOME\r\n\r\n# Check for successful installation\r\nif [ ! -f DayZServer ] || [ ! -f serverDZ.cfg ]; then\r\n    echo -e \"\\n\\n[ERROR] SteamCMD failed to install the DayZ Dedicated Server!\"\r\n    echo -e \"\\tTry reinstalling the server again.\\n\"\r\n    exit 1\r\nfi\r\n\r\n# Add required steamQueryPort parameter to end of default serverDZ.cfg (if it's missing)\r\nif ! grep -q \"steamQueryPort\" serverDZ.cfg; then\r\n    echo -e '\\nAdding required additional parameters to end of default \"serverDZ.cfg\"...'\r\ncat >> serverDZ.cfg << EOL\r\n\r\n\r\nsteamQueryPort = 2305;\r\nEOL\r\nfi\r\n\r\n# Check for BattlEye RCon configuration\r\necho -e '\\nCreating BattlEye RCon Configuration.'\r\ncat > $HOME\/battleye\/beserver_x64.cfg << EOF\r\nRConPort ${RCON_PORT}\r\nRConPassword ${RCON_PASSWORD}\r\nRestrictRCon 0\r\nEOF\r\n\r\necho -e \"\\nDayZ Dedicated Server successfully installed!\\n\"",
             "container": "ghcr.io\/parkervcp\/installers:debian",
             "entrypoint": "\/bin\/bash"
         }
@@ -138,6 +138,28 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": "nullable|string",
+            "sort": null,
+            "field_type": "text"
+        },
+        {
+            "name": "RCON Port",
+            "description": "Used by Tools or Battlemetrics to manage servers from outside. RCON Port is recommended to be at Game Port +3. For example, If the Game Port is 2302, then RCON Port should be 2305.",
+            "env_variable": "RCON_PORT",
+            "default_value": "2305",
+            "user_viewable": true,
+            "user_editable": false,
+            "rules": "required|integer|between:1024,65536",
+            "sort": null,
+            "field_type": "text"
+        },
+        {
+            "name": "RCON Password",
+            "description": "This password is used to authenticate third parties to access server controls via RCON.",
+            "env_variable": "RCON_PASSWORD",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string|max:20",
             "sort": null,
             "field_type": "text"
         },

--- a/dayz/egg-pterodactyl-day-z.json
+++ b/dayz/egg-pterodactyl-day-z.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2024-06-05T20:20:54-07:00",
+    "exported_at": "2024-06-13T12:52:57+07:00",
     "name": "DayZ",
     "author": "red_thirten@yahoo.com",
     "description": "How long can you survive a post-apocalyptic world? A land overrun with an infected \"zombie\" population, where you compete with other survivors for limited resources. Will you team up with strangers and stay strong together? Or play as a lone wolf to avoid betrayal? This is DayZ \u2013 this is your story.",
@@ -15,16 +15,16 @@
         "ghcr.io\/parkervcp\/games:dayz": "ghcr.io\/parkervcp\/games:dayz"
     },
     "file_denylist": [],
-    "startup": ".\/{{SERVER_BINARY}} -port={{SERVER_PORT}} -profiles=profiles -BEpath=battleye -config=serverDZ.cfg -mod={{CLIENT_MODS}} -serverMod={{SERVERMODS}} {{STARTUP_PARAMS}}",
+    "startup": ".\/{{SERVER_BINARY}} -port={{SERVER_PORT}} -profiles=profiles -bepath=.\/ -config=serverDZ.cfg -mod={{CLIENT_MODS}} -serverMod={{SERVERMODS}} {{STARTUP_PARAMS}}",
     "config": {
-        "files": "{\r\n    \"serverDZ.cfg\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"hostname =\": \"hostname = \\\"{{env.SERVER_HOSTNAME}}\\\";\",\r\n            \"password =\": \"password = \\\"{{env.SERVER_PASSWORD}}\\\";\",\r\n            \"passwordAdmin =\": \"passwordAdmin = \\\"{{env.ADMIN_PASSWORD}}\\\";\",\r\n            \"maxPlayers\": \"maxPlayers = {{env.MAX_PLAYERS}};\",\r\n            \"verifySignatures\": \"verifySignatures = {{env.VERIFY_SIGNATURES}};\",\r\n            \"forceSameBuild\": \"forceSameBuild = {{env.ENFORCE_BUILD}};\",\r\n            \"disableVoN\": \"disableVoN = {{env.DISABLE_VON}};\",\r\n            \"vonCodecQuality\": \"vonCodecQuality = {{env.VON_QUALITY}};\",\r\n            \"disable3rdPerson\": \"disable3rdPerson = {{env.DISABLE_THIRD}};\",\r\n            \"disableCrosshair\": \"disableCrosshair = {{env.DISABLE_CROSSHAIR}};\",\r\n            \"disablePersonalLight\": \"disablePersonalLight = {{env.DISABLE_PERSONAL_LIGHT}};\",\r\n            \"lightingConfig\": \"lightingConfig = {{env.LIGHTING_CONFIG}};\",\r\n            \"serverTimeAcceleration\": \"serverTimeAcceleration = {{env.TIME_MULT}};\",\r\n            \"serverNightTimeAcceleration\": \"serverNightTimeAcceleration = {{env.NIGHT_MULT}};\",\r\n            \"serverTimePersistent\": \"serverTimePersistent = {{env.PERSISTENT_TIME}};\",\r\n            \"steamQueryPort\": \"steamQueryPort = {{env.QUERY_PORT}};\"\r\n        }\r\n    }\r\n}",
+        "files": "{\r\n    \"serverDZ.cfg\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"hostname =\": \"hostname = \\\"{{env.SERVER_HOSTNAME}}\\\";\",\r\n            \"password =\": \"password = \\\"{{env.SERVER_PASSWORD}}\\\";\",\r\n            \"passwordAdmin =\": \"passwordAdmin = \\\"{{env.ADMIN_PASSWORD}}\\\";\",\r\n            \"maxPlayers\": \"maxPlayers = {{env.MAX_PLAYERS}};\",\r\n            \"verifySignatures\": \"verifySignatures = {{env.VERIFY_SIGNATURES}};\",\r\n            \"forceSameBuild\": \"forceSameBuild = {{env.ENFORCE_BUILD}};\",\r\n            \"disableVoN\": \"disableVoN = {{env.DISABLE_VON}};\",\r\n            \"vonCodecQuality\": \"vonCodecQuality = {{env.VON_QUALITY}};\",\r\n            \"disable3rdPerson\": \"disable3rdPerson = {{env.DISABLE_THIRD}};\",\r\n            \"disableCrosshair\": \"disableCrosshair = {{env.DISABLE_CROSSHAIR}};\",\r\n            \"disablePersonalLight\": \"disablePersonalLight = {{env.DISABLE_PERSONAL_LIGHT}};\",\r\n            \"lightingConfig\": \"lightingConfig = {{env.LIGHTING_CONFIG}};\",\r\n            \"serverTimeAcceleration\": \"serverTimeAcceleration = {{env.TIME_MULT}};\",\r\n            \"serverNightTimeAcceleration\": \"serverNightTimeAcceleration = {{env.NIGHT_MULT}};\",\r\n            \"serverTimePersistent\": \"serverTimePersistent = {{env.PERSISTENT_TIME}};\",\r\n            \"steamQueryPort\": \"steamQueryPort = {{env.QUERY_PORT}};\"\r\n        }\r\n    },\r\n    \"battleye\/beserver_x64.cfg\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"RConPort\": \"RConPort {{env.RCON_PORT}}\",\r\n            \"RConPassword\": \"RConPassword {{env.RCON_PASSWORD}}\"\r\n        }\r\n    }\r\n}",
         "startup": "{\r\n    \"done\": \"Mission read.\"\r\n}",
         "logs": "{}",
         "stop": "^C"
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/bash\r\n\r\n## File: DayZ Egg - egg-dayz.json\r\n## Author: David Wolfe (Red-Thirten)\r\n## Date: 2024\/06\/05\r\n## License: MIT License\r\n## Image to install with is 'ghcr.io\/parkervcp\/installers:debian'\r\n\r\n## Download and install SteamCMD\r\nexport HOME=\/mnt\/server\r\ncd \/tmp\r\nmkdir -p $HOME\/steamcmd $HOME\/steamapps\r\ncurl -sSL -o steamcmd.tar.gz https:\/\/steamcdn-a.akamaihd.net\/client\/installer\/steamcmd_linux.tar.gz\r\ntar -xzvf steamcmd.tar.gz -C $HOME\/steamcmd\r\ncd $HOME\/steamcmd\r\n\r\n# SteamCMD fails otherwise for some reason, even running as root.\r\n# This is changed at the end of the install process anyways.\r\nchown -R root:root \/mnt\r\n\r\n# Install\/Verify game server using SteamCMD\r\n.\/steamcmd.sh +force_install_dir $HOME \"+login \\\"${STEAM_USER}\\\" \\\"${STEAM_PASS}\\\"\" +app_update ${STEAMCMD_APPID} $( [[ -z ${STEAMCMD_BETAID} ]] || printf %s \"-beta ${STEAMCMD_BETAID}\" ) $( [[ -z ${STEAMCMD_BETAPASS} ]] || printf %s \"-betapassword ${STEAMCMD_BETAPASS}\" ) ${INSTALL_FLAGS} validate +quit\r\n\r\n# Set up 32 and 64 bit libraries\r\nmkdir -p $HOME\/.steam\/sdk{32,64}\r\ncp -v linux32\/steamclient.so $HOME\/.steam\/sdk32\/steamclient.so\r\ncp -v linux64\/steamclient.so $HOME\/.steam\/sdk64\/steamclient.so\r\n\r\n## DayZ Setup\r\ncd $HOME\r\n\r\n# Check for successful installation\r\nif [ ! -f DayZServer ] || [ ! -f serverDZ.cfg ]; then\r\n    echo -e \"\\n\\n[ERROR] SteamCMD failed to install the DayZ Dedicated Server!\"\r\n    echo -e \"\\tTry reinstalling the server again.\\n\"\r\n    exit 1\r\nfi\r\n\r\n# Add required steamQueryPort parameter to end of default serverDZ.cfg (if it's missing)\r\nif ! grep -q \"steamQueryPort\" serverDZ.cfg; then\r\n    echo -e '\\nAdding required additional parameters to end of default \"serverDZ.cfg\"...'\r\ncat >> serverDZ.cfg << EOL\r\n\r\n\r\nsteamQueryPort = 2305;\r\nEOL\r\nfi\r\n\r\necho -e \"\\nDayZ Dedicated Server successfully installed!\\n\"",
+            "script": "#!\/bin\/bash\r\n\r\n## File: DayZ Egg - egg-dayz.json\r\n## Author: David Wolfe (Red-Thirten)\r\n## Date: 2024\/06\/05\r\n## License: MIT License\r\n## Image to install with is 'ghcr.io\/parkervcp\/installers:debian'\r\n\r\n## Download and install SteamCMD\r\nexport HOME=\/mnt\/server\r\ncd \/tmp\r\nmkdir -p $HOME\/steamcmd $HOME\/steamapps\r\ncurl -sSL -o steamcmd.tar.gz https:\/\/steamcdn-a.akamaihd.net\/client\/installer\/steamcmd_linux.tar.gz\r\ntar -xzvf steamcmd.tar.gz -C $HOME\/steamcmd\r\ncd $HOME\/steamcmd\r\n\r\n# SteamCMD fails otherwise for some reason, even running as root.\r\n# This is changed at the end of the install process anyways.\r\nchown -R root:root \/mnt\r\n\r\n# Install\/Verify game server using SteamCMD\r\n.\/steamcmd.sh +force_install_dir $HOME \"+login \\\"${STEAM_USER}\\\" \\\"${STEAM_PASS}\\\"\" +app_update ${STEAMCMD_APPID} $( [[ -z ${STEAMCMD_BETAID} ]] || printf %s \"-beta ${STEAMCMD_BETAID}\" ) $( [[ -z ${STEAMCMD_BETAPASS} ]] || printf %s \"-betapassword ${STEAMCMD_BETAPASS}\" ) ${INSTALL_FLAGS} validate +quit\r\n\r\n# Set up 32 and 64 bit libraries\r\nmkdir -p $HOME\/.steam\/sdk{32,64}\r\ncp -v linux32\/steamclient.so $HOME\/.steam\/sdk32\/steamclient.so\r\ncp -v linux64\/steamclient.so $HOME\/.steam\/sdk64\/steamclient.so\r\n\r\n## DayZ Setup\r\ncd $HOME\r\n\r\n# Check for successful installation\r\nif [ ! -f DayZServer ] || [ ! -f serverDZ.cfg ]; then\r\n    echo -e \"\\n\\n[ERROR] SteamCMD failed to install the DayZ Dedicated Server!\"\r\n    echo -e \"\\tTry reinstalling the server again.\\n\"\r\n    exit 1\r\nfi\r\n\r\n# Add required steamQueryPort parameter to end of default serverDZ.cfg (if it's missing)\r\nif ! grep -q \"steamQueryPort\" serverDZ.cfg; then\r\n    echo -e '\\nAdding required additional parameters to end of default \"serverDZ.cfg\"...'\r\ncat >> serverDZ.cfg << EOL\r\n\r\n\r\nsteamQueryPort = 2305;\r\nEOL\r\nfi\r\n\r\n# Check for BattlEye RCon configuration\r\necho -e '\\nCreating BattlEye RCon Configuration.'\r\ncat > $HOME\/battleye\/beserver_x64.cfg << EOF\r\nRConPort ${RCON_PORT}\r\nRConPassword ${RCON_PASSWORD}\r\nRestrictRCon 0\r\nEOF\r\n\r\necho -e \"\\nDayZ Dedicated Server successfully installed!\\n\"",
             "container": "ghcr.io\/parkervcp\/installers:debian",
             "entrypoint": "\/bin\/bash"
         }
@@ -128,6 +128,26 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": "nullable|string",
+            "field_type": "text"
+        },
+        {
+            "name": "RCON Port",
+            "description": "Used by Tools or Battlemetrics to manage servers from outside. RCON Port is recommended to be at Game Port +3. For example, If the Game Port is 2302, then RCON Port should be 2305.",
+            "env_variable": "RCON_PORT",
+            "default_value": "2305",
+            "user_viewable": true,
+            "user_editable": false,
+            "rules": "required|integer|between:1024,65536",
+            "field_type": "text"
+        },
+        {
+            "name": "RCON Password",
+            "description": "This password is used to authenticate third parties to access server controls via RCON.",
+            "env_variable": "RCON_PASSWORD",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string|max:20",
             "field_type": "text"
         },
         {


### PR DESCRIPTION
# Description

- Fixes the battleye directory (--bepath startup params) that going too deep from the default one (It was "/battleye/battleye/" instead of "/battleye/"). 
- BattlEye configuration (beserver_64.cfg) will be generated automatically by installation script. 
- The RCON Port and Password can also be changed via variables and will be applied when the server is started.

## Checklist for all submissions

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- If this is an egg update fill these out -->

* [x] You verify that the start command applied does not use a shell script
* [x] The egg was exported from the panel