### PR TITLE
[V Rising] Update Default Image

### DIFF
--- a/v_rising/v_rising_vanilla/egg-pterodactyl-v-rising.json
+++ b/v_rising/v_rising_vanilla/egg-pterodactyl-v-rising.json
@@ -1,10 +1,10 @@
 {
-    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
+    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
-        "update_url": null,
-        "version": "PTDL_v2"
+        "version": "PTDL_v2",
+        "update_url": null
     },
-    "exported_at": "2024-06-01T00:05:06+00:00",
+    "exported_at": "2024-08-02T10:52:39-07:00",
     "name": "V Rising",
     "author": "red_thirten@yahoo.com",
     "description": "Awaken as a vampire. Hunt for blood in nearby settlements to regain your strength and evade the scorching sun to survive. Raise your castle and thrive in an ever-changing open world full of mystery. Gain allies online and conquer the land of the living.",
@@ -12,21 +12,22 @@
         "steam_disk_space"
     ],
     "docker_images": {
-        "ghcr.io/parkervcp/yolks:wine_staging": "ghcr.io/parkervcp/yolks:wine_staging"
+        "Wine (Latest)": "ghcr.io\/parkervcp\/yolks:wine_latest",
+        "Wine (Staging)": "ghcr.io\/parkervcp\/yolks:wine_staging"
     },
     "file_denylist": [],
-    "startup": "wine ./VRisingServer.exe -address 0.0.0.0 -gamePort {{SERVER_PORT}} -persistentDataPath save-data",
+    "startup": "wine .\/VRisingServer.exe -address 0.0.0.0 -gamePort {{SERVER_PORT}} -persistentDataPath save-data",
     "config": {
         "files": "{}",
-        "logs": "{}",
         "startup": "{\r\n    \"done\": \"[Server] Startup Completed\"\r\n}",
+        "logs": "{}",
         "stop": "^C"
     },
     "scripts": {
         "installation": {
-            "container": "ghcr.io/parkervcp/installers:debian",
-            "entrypoint": "/bin/bash",
-            "script": "#!/bin/bash\r\n\r\n## File: V Rising Egg - egg-v-rising.json\r\n## Authors: David Wolfe (Red-Thirten), Kapatheus\r\n## Date: 2024/05/09\r\n## License: MIT License\r\n## Image to install with is 'ghcr.io/parkervcp/installers:debian'\r\n\r\n# Download and install SteamCMD\r\nexport HOME=/mnt/server\r\ncd /tmp\r\nmkdir -p $HOME/steamcmd $HOME/steamapps\r\ncurl -sSL -o steamcmd.tar.gz https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz\r\ntar -xzvf steamcmd.tar.gz -C $HOME/steamcmd\r\ncd $HOME/steamcmd\r\n\r\n# SteamCMD fails otherwise for some reason, even running as root.\r\n# This is changed at the end of the install process anyways.\r\nchown -R root:root /mnt\r\n\r\n# Install/Verify game server using SteamCMD\r\n./steamcmd.sh +force_install_dir $HOME +login anonymous $( [[ \"${WINDOWS_INSTALL}\" == \"1\" ]] \u0026\u0026 printf %s '+@sSteamCmdForcePlatformType windows' ) +app_update ${SRCDS_APPID} validate +quit\r\n\r\n# Set up 32 and 64 bit libraries\r\nmkdir -p $HOME/.steam/sdk{32,64}\r\ncp -v linux32/steamclient.so $HOME/.steam/sdk32/steamclient.so\r\ncp -v linux64/steamclient.so $HOME/.steam/sdk64/steamclient.so\r\n\r\n## V Rising Setup\r\nmkdir -p $HOME/save-data/Settings\r\n# Check for successful installation.\r\ncd $HOME/VRisingServer_Data/StreamingAssets/Settings\r\nif [[ -f ServerHostSettings.json ]]; then\r\n    echo -e \"\\nV Rising Dedicated Server successfully installed!\\n\"\r\nelse\r\n    echo -e \"\\n\\nSteamCMD failed to install the V Rising Dedicated Server!\"\r\n    echo -e \"\\tTry reinstalling the server again.\\n\"\r\n    exit 1\r\nfi"
+            "script": "#!\/bin\/bash\r\n\r\n## File: V Rising Egg - egg-v-rising.json\r\n## Authors: David Wolfe (Red-Thirten), Kapatheus\r\n## Date: 2024\/08\/02\r\n## License: MIT License\r\n## Image to install with is 'ghcr.io\/parkervcp\/installers:debian'\r\n\r\n# Download and install SteamCMD\r\nexport HOME=\/mnt\/server\r\ncd \/tmp\r\nmkdir -p $HOME\/steamcmd $HOME\/steamapps\r\ncurl -sSL -o steamcmd.tar.gz https:\/\/steamcdn-a.akamaihd.net\/client\/installer\/steamcmd_linux.tar.gz\r\ntar -xzvf steamcmd.tar.gz -C $HOME\/steamcmd\r\ncd $HOME\/steamcmd\r\n\r\n# SteamCMD fails otherwise for some reason, even running as root.\r\n# This is changed at the end of the install process anyways.\r\nchown -R root:root \/mnt\r\n\r\n# Install\/Verify game server using SteamCMD\r\n.\/steamcmd.sh +force_install_dir $HOME +login anonymous $( [[ \"${WINDOWS_INSTALL}\" == \"1\" ]] && printf %s '+@sSteamCmdForcePlatformType windows' ) +app_update ${SRCDS_APPID} validate +quit\r\n\r\n# Set up 32 and 64 bit libraries\r\nmkdir -p $HOME\/.steam\/sdk{32,64}\r\ncp -v linux32\/steamclient.so $HOME\/.steam\/sdk32\/steamclient.so\r\ncp -v linux64\/steamclient.so $HOME\/.steam\/sdk64\/steamclient.so\r\n\r\n## V Rising Setup\r\nmkdir -p $HOME\/save-data\/Settings\r\n# Check for successful installation.\r\ncd $HOME\/VRisingServer_Data\/StreamingAssets\/Settings\r\nif [[ -f ServerHostSettings.json ]]; then\r\n    echo -e \"\\nV Rising Dedicated Server successfully installed!\\n\"\r\nelse\r\n    echo -e \"\\n\\nSteamCMD failed to install the V Rising Dedicated Server!\"\r\n    echo -e \"\\tTry reinstalling the server again.\\n\"\r\n    exit 1\r\nfi",
+            "container": "ghcr.io\/parkervcp\/installers:debian",
+            "entrypoint": "\/bin\/bash"
         }
     },
     "variables": [
@@ -42,7 +43,7 @@
         },
         {
             "name": "[Host] Hide IP Address",
-            "description": "When listing server on EOS server list, the IP address will not be shown/advertised. Players will connect via relay servers.",
+            "description": "When listing server on EOS server list, the IP address will not be shown\/advertised. Players will connect via relay servers.",
             "env_variable": "VR_HIDEIPADDRESS",
             "default_value": "false",
             "user_viewable": false,
@@ -62,7 +63,7 @@
         },
         {
             "name": "Game Settings Preset",
-            "description": "What preset of game settings the server should run. Some settings may not apply after the save file is first created. Leave empty/null if you are using a single-player uploaded save or a custom ServerGameSettings.json file in the `~/save-data/Settings/` directory.",
+            "description": "What preset of game settings the server should run. Some settings may not apply after the save file is first created. Leave empty\/null if you are using a single-player uploaded save or a custom ServerGameSettings.json file in the `~\/save-data\/Settings\/` directory.",
             "env_variable": "VR_PRESET",
             "default_value": "",
             "user_viewable": true,
@@ -72,7 +73,7 @@
         },
         {
             "name": "Game Difficulty Preset",
-            "description": "What preset of game difficulty the server should run. Some settings may not apply after the save file is first created. Leave empty/null if you are using a single-player uploaded save or a custom ServerGameSettings.json file in the `~/save-data/Settings/` directory.",
+            "description": "What preset of game difficulty the server should run. Some settings may not apply after the save file is first created. Leave empty\/null if you are using a single-player uploaded save or a custom ServerGameSettings.json file in the `~\/save-data\/Settings\/` directory.",
             "env_variable": "VR_DIFFICULTY_PRESET",
             "default_value": "Difficulty_Normal",
             "user_viewable": true,
@@ -142,7 +143,7 @@
         },
         {
             "name": "Save Name",
-            "description": "Name of save file / directory.",
+            "description": "Name of save file \/ directory.",
             "env_variable": "VR_SAVE_NAME",
             "default_value": "world1",
             "user_viewable": true,
@@ -222,7 +223,7 @@
         },
         {
             "name": "[RCON] Enable RCON",
-            "description": "Enable or disable RCON functionality. (true | false) See the following link for info on how to connect and use RCON: https://github.com/StunlockStudios/vrising-dedicated-server-instructions/blob/master/1.0.x/INSTRUCTIONS.md#rcon-1",
+            "description": "Enable or disable RCON functionality. (true | false) See the following link for info on how to connect and use RCON: https:\/\/github.com\/StunlockStudios\/vrising-dedicated-server-instructions\/blob\/master\/1.0.x\/INSTRUCTIONS.md#rcon-1",
             "env_variable": "VR_RCON_ENABLED",
             "default_value": "false",
             "user_viewable": true,
@@ -272,7 +273,7 @@
         },
         {
             "name": "[System] Use Windows Branch",
-            "description": "Tells the installer/updater to only download the Windows branch of the server (the only branch currently available) so that it can run on Wine. Cannot be changed.",
+            "description": "Tells the installer\/updater to only download the Windows branch of the server (the only branch currently available) so that it can run on Wine. Cannot be changed.",
             "env_variable": "WINDOWS_INSTALL",
             "default_value": "1",
             "user_viewable": false,
@@ -304,10 +305,10 @@
             "name": "[System] WINEPATH",
             "description": "Used for compatibility. Cannot be changed.",
             "env_variable": "WINEPATH",
-            "default_value": "/home/container",
+            "default_value": "\/home\/container",
             "user_viewable": false,
             "user_editable": false,
-            "rules": "required|string|in:/home/container",
+            "rules": "required|string|in:\/home\/container",
             "field_type": "text"
         }
     ]

--- a/v_rising/v_rising_vanilla/egg-v-rising.json
+++ b/v_rising/v_rising_vanilla/egg-v-rising.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2024-06-01T00:05:06+00:00",
+    "exported_at": "2024-08-02T10:52:39-07:00",
     "name": "V Rising",
     "author": "red_thirten@yahoo.com",
     "uuid": "c61c5708-33ee-45c2-a878-bdb2e34627f5",
@@ -13,7 +13,8 @@
         "steam_disk_space"
     ],
     "docker_images": {
-        "ghcr.io\/parkervcp\/yolks:wine_staging": "ghcr.io\/parkervcp\/yolks:wine_staging"
+        "Wine (Latest)": "ghcr.io\/parkervcp\/yolks:wine_latest",
+        "Wine (Staging)": "ghcr.io\/parkervcp\/yolks:wine_staging"
     },
     "file_denylist": [],
     "startup": "wine .\/VRisingServer.exe -address 0.0.0.0 -gamePort {{SERVER_PORT}} -persistentDataPath save-data",
@@ -25,7 +26,7 @@
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/bash\r\n\r\n## File: V Rising Egg - egg-v-rising.json\r\n## Authors: David Wolfe (Red-Thirten), Kapatheus\r\n## Date: 2024\/05\/09\r\n## License: MIT License\r\n## Image to install with is 'ghcr.io\/parkervcp\/installers:debian'\r\n\r\n# Download and install SteamCMD\r\nexport HOME=\/mnt\/server\r\ncd \/tmp\r\nmkdir -p $HOME\/steamcmd $HOME\/steamapps\r\ncurl -sSL -o steamcmd.tar.gz https:\/\/steamcdn-a.akamaihd.net\/client\/installer\/steamcmd_linux.tar.gz\r\ntar -xzvf steamcmd.tar.gz -C $HOME\/steamcmd\r\ncd $HOME\/steamcmd\r\n\r\n# SteamCMD fails otherwise for some reason, even running as root.\r\n# This is changed at the end of the install process anyways.\r\nchown -R root:root \/mnt\r\n\r\n# Install\/Verify game server using SteamCMD\r\n.\/steamcmd.sh +force_install_dir $HOME +login anonymous $( [[ \"${WINDOWS_INSTALL}\" == \"1\" ]] && printf %s '+@sSteamCmdForcePlatformType windows' ) +app_update ${SRCDS_APPID} validate +quit\r\n\r\n# Set up 32 and 64 bit libraries\r\nmkdir -p $HOME\/.steam\/sdk{32,64}\r\ncp -v linux32\/steamclient.so $HOME\/.steam\/sdk32\/steamclient.so\r\ncp -v linux64\/steamclient.so $HOME\/.steam\/sdk64\/steamclient.so\r\n\r\n## V Rising Setup\r\nmkdir -p $HOME\/save-data\/Settings\r\n# Check for successful installation.\r\ncd $HOME\/VRisingServer_Data\/StreamingAssets\/Settings\r\nif [[ -f ServerHostSettings.json ]]; then\r\n    echo -e \"\\nV Rising Dedicated Server successfully installed!\\n\"\r\nelse\r\n    echo -e \"\\n\\nSteamCMD failed to install the V Rising Dedicated Server!\"\r\n    echo -e \"\\tTry reinstalling the server again.\\n\"\r\n    exit 1\r\nfi",
+            "script": "#!\/bin\/bash\r\n\r\n## File: V Rising Egg - egg-v-rising.json\r\n## Authors: David Wolfe (Red-Thirten), Kapatheus\r\n## Date: 2024\/08\/02\r\n## License: MIT License\r\n## Image to install with is 'ghcr.io\/parkervcp\/installers:debian'\r\n\r\n# Download and install SteamCMD\r\nexport HOME=\/mnt\/server\r\ncd \/tmp\r\nmkdir -p $HOME\/steamcmd $HOME\/steamapps\r\ncurl -sSL -o steamcmd.tar.gz https:\/\/steamcdn-a.akamaihd.net\/client\/installer\/steamcmd_linux.tar.gz\r\ntar -xzvf steamcmd.tar.gz -C $HOME\/steamcmd\r\ncd $HOME\/steamcmd\r\n\r\n# SteamCMD fails otherwise for some reason, even running as root.\r\n# This is changed at the end of the install process anyways.\r\nchown -R root:root \/mnt\r\n\r\n# Install\/Verify game server using SteamCMD\r\n.\/steamcmd.sh +force_install_dir $HOME +login anonymous $( [[ \"${WINDOWS_INSTALL}\" == \"1\" ]] && printf %s '+@sSteamCmdForcePlatformType windows' ) +app_update ${SRCDS_APPID} validate +quit\r\n\r\n# Set up 32 and 64 bit libraries\r\nmkdir -p $HOME\/.steam\/sdk{32,64}\r\ncp -v linux32\/steamclient.so $HOME\/.steam\/sdk32\/steamclient.so\r\ncp -v linux64\/steamclient.so $HOME\/.steam\/sdk64\/steamclient.so\r\n\r\n## V Rising Setup\r\nmkdir -p $HOME\/save-data\/Settings\r\n# Check for successful installation.\r\ncd $HOME\/VRisingServer_Data\/StreamingAssets\/Settings\r\nif [[ -f ServerHostSettings.json ]]; then\r\n    echo -e \"\\nV Rising Dedicated Server successfully installed!\\n\"\r\nelse\r\n    echo -e \"\\n\\nSteamCMD failed to install the V Rising Dedicated Server!\"\r\n    echo -e \"\\tTry reinstalling the server again.\\n\"\r\n    exit 1\r\nfi",
             "container": "ghcr.io\/parkervcp\/installers:debian",
             "entrypoint": "\/bin\/bash"
         }


### PR DESCRIPTION
# Description

This PR is currently for the Vanilla Egg only, but may need to be extended to BepInEx as well.

- Changes the default image to `wine_latest`. `wine_staging` is left as an option, but currently has a library issue preventing the server from starting (see #56).
- The Pterodactyl Egg has been re-exported to fix various special character escapes.
- The only change to the installation script is the date.

Fixes #56 

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?

<!-- If this is an egg update fill these out -->

* [x] You verify that the start command applied does not use a shell script
* [x] The egg was exported from the panel