### PR TITLE
Bind Satisfactory http query server to `0.0.0.0`

### DIFF
--- a/satisfactory/egg-pterodactyl-satisfactory.json
+++ b/satisfactory/egg-pterodactyl-satisfactory.json
@@ -15,7 +15,7 @@
         "ghcr.io\/parkervcp\/steamcmd:debian": "ghcr.io\/parkervcp\/steamcmd:debian"
     },
     "file_denylist": [],
-    "startup": ".\/Engine\/Binaries\/Linux\/*-Linux-Shipping FactoryGame ?listen -Port={{SERVER_PORT}}",
+    "startup": ".\/Engine\/Binaries\/Linux\/*-Linux-Shipping FactoryGame ?listen -Port={{SERVER_PORT}} -ini:Engine:[HTTPServer.Listeners]:DefaultBindAddress=any",
     "config": {
         "files": "{\r\n    \"FactoryGame\/Saved\/Config\/LinuxServer\/Game.ini\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"MaxPlayers\": \"MaxPlayers={{server.build.env.MAX_PLAYERS}}\"\r\n        }\r\n    },\r\n    \"FactoryGame\/Saved\/Config\/LinuxServer\/Engine.ini\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"mNumRotatingAutosaves\": \"mNumRotatingAutosaves={{server.build.env.NUM_AUTOSAVES}}\",\r\n            \"bImplicitSend\": \"bImplicitSend={{server.build.env.UPLOAD_CRASH_REPORT}}\",\r\n            \"InitialConnectTimeout\": \"InitialConnectTimeout={{server.build.env.INIT_CONNECT_TIMEOUT}}\",\r\n            \"ConnectionTimeout\": \"ConnectionTimeout={{server.build.env.CONNECT_TIMEOUT}}\"\r\n        }\r\n    }\r\n}",
         "startup": "{\r\n    \"done\": \"Engine Initialization\"\r\n}",

--- a/satisfactory/egg-satisfactory.json
+++ b/satisfactory/egg-satisfactory.json
@@ -16,7 +16,7 @@
         "ghcr.io\/parkervcp\/steamcmd:debian": "ghcr.io\/parkervcp\/steamcmd:debian"
     },
     "file_denylist": [],
-    "startup": ".\/Engine\/Binaries\/Linux\/*-Linux-Shipping FactoryGame ?listen -port={{SERVER_PORT}}",
+    "startup": ".\/Engine\/Binaries\/Linux\/*-Linux-Shipping FactoryGame ?listen -port={{SERVER_PORT}} -ini:Engine:[HTTPServer.Listeners]:DefaultBindAddress=any",
     "config": {
         "files": "{\n    \"FactoryGame\/Saved\/Config\/LinuxServer\/Game.ini\": {\n        \"parser\": \"file\",\n        \"find\": {\n            \"MaxPlayers\": \"MaxPlayers={{server.environment.MAX_PLAYERS}}\"\n        }\n    },\n    \"FactoryGame\/Saved\/Config\/LinuxServer\/Engine.ini\": {\n        \"parser\": \"file\",\n        \"find\": {\n            \"mNumRotatingAutosaves\": \"mNumRotatingAutosaves={{server.environment.NUM_AUTOSAVES}}\",\n            \"bImplicitSend\": \"bImplicitSend={{server.environment.UPLOAD_CRASH_REPORT}}\",\n            \"InitialConnectTimeout\": \"InitialConnectTimeout={{server.environment.INIT_CONNECT_TIMEOUT}}\",\n            \"ConnectionTimeout\": \"ConnectionTimeout={{server.environment.CONNECT_TIMEOUT}}\"\n        }\n    }\n}",
         "startup": "{\r\n    \"done\": \"Engine Initialization\"\r\n}",


### PR DESCRIPTION
# Description

<!-- Please explain what is being changed or added as a short overview for this PR. Also, link existing relevant issues if they exist with resolves # -->

- simple fix to fix the "Failed to Connect to the Server API" error
- caused because the http query server binds to localhost of the container (seen in the start up logs)
- the extra startup param binds it to `0.0.0.0`

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
    * #78 includes changes for Satisfactory 1.0, but not this fix
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [ ] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- If this is an egg update fill these out -->

* [x] You verify that the start command applied does not use a shell script
  * [ ] If some script is needed then it is part of a current yolk or a PR to add one
* [ ] The egg was exported from the panel

<!-- You can erase the new egg submission template if you're not adding a completely new egg -->
