### PR TITLE
[Arma Reforger] Fix "Invalid platform" SteamCMD installation error

### DIFF
--- a/arma/arma_reforger/README.md
+++ b/arma/arma_reforger/README.md
@@ -60,6 +60,12 @@ ___
 
 ### Installation/System Requirements
 
+> [!IMPORTANT]
+> [As of 2024-11-27] A real, valid Steam account is required to install this game server.
+
+> [!WARNING]
+> Steam Guard **must** be completely **turned off** for the server to download correctly!
+
 |  | Bare Minimum | Recommended |
 |---------|---------|---------|
 | Processor | Recent x86/64 (AMD/Intel) processor. No ARM support. | Can use up to 300-600% CPU under load with uncapped FPS (set Max FPS to prevent). |

--- a/arma/arma_reforger/egg-arma-reforger.json
+++ b/arma/arma_reforger/egg-arma-reforger.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2024-07-03T21:46:20-07:00",
+    "exported_at": "2024-11-28T14:47:08-08:00",
     "name": "Arma Reforger",
     "author": "red_thirten@yahoo.com",
     "uuid": "7c4dc3db-fac9-4d2d-8551-0c266e85cc50",
@@ -25,12 +25,34 @@
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/bash\r\n\r\n## File: Pelican Arma Reforger Egg - egg-arma-reforger.json\r\n## Author: David Wolfe (Red-Thirten)\r\n## Date: 2024\/07\/03\r\n## License: MIT License\r\n## Image to install with is 'ghcr.io\/parkervcp\/installers:debian'\r\n\r\n## Download and install SteamCMD\r\nexport HOME=\/mnt\/server\r\ncd \/tmp\r\nmkdir -p $HOME\/steamcmd $HOME\/steamapps\r\ncurl -sSL -o steamcmd.tar.gz https:\/\/steamcdn-a.akamaihd.net\/client\/installer\/steamcmd_linux.tar.gz\r\ntar -xzvf steamcmd.tar.gz -C $HOME\/steamcmd\r\ncd $HOME\/steamcmd\r\n\r\n# SteamCMD fails otherwise for some reason, even running as root.\r\nchown -R root:root \/mnt\r\n\r\n# Install\/Verify game server using SteamCMD\r\n.\/steamcmd.sh +force_install_dir $HOME +login anonymous $( [[ \"${WINDOWS_INSTALL}\" == \"1\" ]] && printf %s '+@sSteamCmdForcePlatformType windows' ) +app_update ${SRCDS_APPID} +app_update 1007 $( [[ -z ${SRCDS_BETAID} ]] || printf %s \"-beta ${SRCDS_BETAID}\" ) $( [[ -z ${SRCDS_BETAPASS} ]] || printf %s \"-betapassword ${SRCDS_BETAPASS}\" ) validate +quit\r\n\r\n# Set up 32 and 64 bit libraries\r\nmkdir -p \/mnt\/server\/.steam\/sdk{32,64}\r\ncp -v linux32\/steamclient.so \/mnt\/server\/.steam\/sdk32\/steamclient.so\r\ncp -v linux64\/steamclient.so \/mnt\/server\/.steam\/sdk64\/steamclient.so\r\n\r\n## Arma Reforger setup\r\n# Check for successful installation\r\nif [[ ! -f $HOME\/ArmaReforgerServer ]]; then\r\n    echo -e \"\\n\\nSteamCMD failed to install the Arma Reforger Dedicated Server!\"\r\n    echo -e \"\\tTry reinstalling the server again.\\n\"\r\n    exit 1\r\nfi\r\n\r\nmkdir -p $HOME\/profile $HOME\/tmp\r\n\r\necho -e 'Creating default \"config.json\" configuration file...'\r\ncat > $HOME\/config.json << EOF\r\n{\r\n\t\"bindAddress\": \"0.0.0.0\",\r\n\t\"bindPort\": ${SERVER_PORT},\r\n\t\"publicAddress\": \"${SERVER_IP}\",\r\n\t\"publicPort\": ${SERVER_PORT},\r\n\t\"game\": {\r\n\t\t\"name\": \"${SERVER_NAME}\",\r\n\t\t\"password\": \"${SERVER_PASS}\",\r\n\t\t\"passwordAdmin\": \"${ADMIN_PASS}\",\r\n\t\t\"admins\" : [],\r\n\t\t\"scenarioId\": \"${SCENARIO_ID}\",\r\n\t\t\"maxPlayers\": ${MAX_PLAYERS},\r\n\t\t\"visible\": ${VISIBLE},\r\n\t\t\"gameProperties\": {\r\n\t\t\t\"serverMaxViewDistance\": 2500,\r\n\t\t\t\"serverMinGrassDistance\": 50,\r\n\t\t\t\"networkViewDistance\": 1000,\r\n\t\t\t\"disableThirdPerson\": ${DISABLE_THIRD},\r\n\t\t\t\"fastValidation\": true,\r\n\t\t\t\"battlEye\": ${BATTLEYE},\r\n\t\t\t\"VONDisableUI\": false,\r\n\t\t\t\"VONDisableDirectSpeechUI\": false\r\n\t\t},\r\n\t\t\"mods\": []\r\n\t}\r\n}\r\nEOF\r\n\r\necho -e \"\\nArma Reforger Dedicated Server successfully installed!\\n\"",
+            "script": "#!\/bin\/bash\r\n\r\n## File: Pelican Arma Reforger Egg - egg-arma-reforger.json\r\n## Author: David Wolfe (Red-Thirten)\r\n## Date: 2024\/11\/28\r\n## License: MIT License\r\n## Image to install with is 'ghcr.io\/parkervcp\/installers:debian'\r\n\r\n# Check for valid Steam credentials to download Arma Reforger with (requires valid Steam account)\r\nif [[ \"${STEAM_USER}\" == \"\" ]] || [[ \"${STEAM_USER}\" == \"anonymous\" ]] || [[ \"${STEAM_PASS}\" == \"\" ]]; then\r\n    echo -e \"INSTALLATION ERROR: A valid REAL Steam account is required to download the Arma Reforger Dedicated Server.\"\r\n    echo -e \"\\t(\\\"anonymous\\\" account cannot be used. Game ownership is not required.)\"\r\n    exit 1\r\nfi\r\n\r\n## Download and install SteamCMD\r\nexport HOME=\/mnt\/server\r\ncd \/tmp\r\nmkdir -p $HOME\/steamcmd $HOME\/steamapps\r\ncurl -sSL -o steamcmd.tar.gz https:\/\/steamcdn-a.akamaihd.net\/client\/installer\/steamcmd_linux.tar.gz\r\ntar -xzvf steamcmd.tar.gz -C $HOME\/steamcmd\r\ncd $HOME\/steamcmd\r\n\r\n# SteamCMD fails otherwise for some reason, even running as root.\r\nchown -R root:root \/mnt\r\n\r\n# Install\/Verify game server using SteamCMD\r\n.\/steamcmd.sh +force_install_dir $HOME \"+login \\\"${STEAM_USER}\\\" \\\"${STEAM_PASS}\\\"\" $( [[ \"${WINDOWS_INSTALL}\" == \"1\" ]] && printf %s '+@sSteamCmdForcePlatformType windows' ) +app_update ${SRCDS_APPID} +app_update 1007 $( [[ -z ${SRCDS_BETAID} ]] || printf %s \"-beta ${SRCDS_BETAID}\" ) $( [[ -z ${SRCDS_BETAPASS} ]] || printf %s \"-betapassword ${SRCDS_BETAPASS}\" ) validate +quit\r\n\r\n# Set up 32 and 64 bit libraries\r\nmkdir -p \/mnt\/server\/.steam\/sdk{32,64}\r\ncp -v linux32\/steamclient.so \/mnt\/server\/.steam\/sdk32\/steamclient.so\r\ncp -v linux64\/steamclient.so \/mnt\/server\/.steam\/sdk64\/steamclient.so\r\n\r\n## Arma Reforger setup\r\n# Check for successful installation\r\nif [[ ! -f $HOME\/ArmaReforgerServer ]]; then\r\n    echo -e \"\\n\\nSteamCMD failed to install the Arma Reforger Dedicated Server!\"\r\n    echo -e \"\\tTry reinstalling the server again.\\n\"\r\n    exit 1\r\nfi\r\n\r\nmkdir -p $HOME\/profile $HOME\/tmp\r\n\r\necho -e 'Creating default \"config.json\" configuration file...'\r\ncat > $HOME\/config.json << EOF\r\n{\r\n\t\"bindAddress\": \"0.0.0.0\",\r\n\t\"bindPort\": ${SERVER_PORT},\r\n\t\"publicAddress\": \"${SERVER_IP}\",\r\n\t\"publicPort\": ${SERVER_PORT},\r\n\t\"game\": {\r\n\t\t\"name\": \"${SERVER_NAME}\",\r\n\t\t\"password\": \"${SERVER_PASS}\",\r\n\t\t\"passwordAdmin\": \"${ADMIN_PASS}\",\r\n\t\t\"admins\" : [],\r\n\t\t\"scenarioId\": \"${SCENARIO_ID}\",\r\n\t\t\"maxPlayers\": ${MAX_PLAYERS},\r\n\t\t\"visible\": ${VISIBLE},\r\n\t\t\"gameProperties\": {\r\n\t\t\t\"serverMaxViewDistance\": 2500,\r\n\t\t\t\"serverMinGrassDistance\": 50,\r\n\t\t\t\"networkViewDistance\": 1000,\r\n\t\t\t\"disableThirdPerson\": ${DISABLE_THIRD},\r\n\t\t\t\"fastValidation\": true,\r\n\t\t\t\"battlEye\": ${BATTLEYE},\r\n\t\t\t\"VONDisableUI\": false,\r\n\t\t\t\"VONDisableDirectSpeechUI\": false\r\n\t\t},\r\n\t\t\"mods\": []\r\n\t}\r\n}\r\nEOF\r\n\r\necho -e \"\\nArma Reforger Dedicated Server successfully installed!\\n\"",
             "container": "ghcr.io\/parkervcp\/installers:debian",
             "entrypoint": "\/bin\/bash"
         }
     },
     "variables": [
+        {
+            "name": "[REQUIRED] Steam Username",
+            "description": "Used for installation and updates. Account does not need to own Arma Reforger, but MUST BE a VALID Steam account (anonymous login cannot be used). For security reasons it is recommended that you create a new Steam account just for your dedicated servers. *This info is not visible to the server owner.*",
+            "env_variable": "STEAM_USER",
+            "default_value": "",
+            "user_viewable": false,
+            "user_editable": false,
+            "rules": "required|string",
+            "sort": 1,
+            "field_type": "text"
+        },
+        {
+            "name": "[REQUIRED] Steam Password",
+            "description": "Used for installation and updates. Steam Guard MUST be completely TURNED OFF for install to complete successfully. *This info is not visible to the server owner, BUT IS stored in PLAIN TEXT. It is NOT advised to use a personal account; best to use a dummy account.*",
+            "env_variable": "STEAM_PASS",
+            "default_value": "",
+            "user_viewable": false,
+            "user_editable": false,
+            "rules": "required|string",
+            "sort": 2,
+            "field_type": "text"
+        },
         {
             "name": "Automatic Updates",
             "description": "Quickly checks for any server or mod updates on startup, and updates if necessary.",
@@ -39,7 +61,7 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": "boolean",
-            "sort": 1,
+            "sort": 3,
             "field_type": "text"
         },
         {
@@ -50,7 +72,7 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|string|in:AD,AE,AF,AG,AI,AL,AM,AO,AQ,AR,AS,AT,AU,AW,AX,AZ,BA,BB,BD,BE,BF,BG,BH,BI,BJ,BL,BM,BN,BO,BQ,BR,BS,BT,BV,BW,BY,BZ,CA,CC,CD,CF,CG,CH,CI,CK,CL,CM,CN,CO,CR,CU,CV,CW,CX,CY,CZ,DE,DJ,DK,DM,DO,DZ,EC,EE,EG,EH,ER,ES,ET,EU,FI,FJ,FK,FM,FO,FR,GA,GB,GD,GE,GF,GG,GH,GI,GL,GM,GN,GP,GQ,GR,GS,GT,GU,GW,GY,HK,HM,HN,HR,HT,HU,ID,IE,IL,IM,IN,IO,IQ,IR,IS,IT,JE,JM,JO,JP,KE,KG,KH,KI,KM,KN,KP,KR,KW,KY,KZ,LA,LB,LC,LI,LK,LR,LS,LT,LU,LV,LY,MA,MC,MD,ME,MF,MG,MH,MK,ML,MM,MN,MO,MP,MQ,MR,MS,MT,MU,MV,MW,MX,MY,MZ,NA,NC,NE,NF,NG,NI,NL,NO,NP,NR,NU,NZ,OM,PA,PE,PF,PG,PH,PK,PL,PM,PN,PR,PS,PT,PW,PY,QA,RE,RO,RS,RU,RW,SA,SB,SC,SD,SE,SG,SH,SI,SJ,SK,SL,SM,SN,SO,SR,SS,ST,SV,SX,SY,SZ,TC,TD,TF,TG,TH,TJ,TK,TL,TM,TN,TO,TR,TT,TV,TW,TZ,UA,UG,UM,US,UY,UZ,VA,VC,VE,VG,VI,VN,VU,WF,WS,YE,YT,ZA,ZM,ZW",
-            "sort": 2,
+            "sort": 4,
             "field_type": "text"
         },
         {
@@ -61,7 +83,7 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|string|max:255",
-            "sort": 3,
+            "sort": 5,
             "field_type": "text"
         },
         {
@@ -72,7 +94,7 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|integer|between:1,256",
-            "sort": 4,
+            "sort": 6,
             "field_type": "text"
         },
         {
@@ -83,7 +105,7 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": "nullable|string|max:32",
-            "sort": 5,
+            "sort": 7,
             "field_type": "text"
         },
         {
@@ -94,7 +116,7 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": "nullable|string|max:32",
-            "sort": 6,
+            "sort": 8,
             "field_type": "text"
         },
         {
@@ -105,7 +127,7 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|string",
-            "sort": 7,
+            "sort": 9,
             "field_type": "text"
         },
         {
@@ -116,7 +138,7 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|string|in:true,false",
-            "sort": 8,
+            "sort": 10,
             "field_type": "text"
         },
         {
@@ -127,7 +149,7 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|string|in:true,false",
-            "sort": 9,
+            "sort": 11,
             "field_type": "text"
         },
         {
@@ -138,7 +160,7 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|string|in:true,false",
-            "sort": 10,
+            "sort": 12,
             "field_type": "text"
         },
         {
@@ -149,7 +171,7 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|string|in:true,false",
-            "sort": 11,
+            "sort": 13,
             "field_type": "text"
         },
         {
@@ -160,7 +182,7 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": "nullable|integer|gt:0",
-            "sort": 12,
+            "sort": 14,
             "field_type": "text"
         },
         {
@@ -171,7 +193,7 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|integer|min:0",
-            "sort": 13,
+            "sort": 15,
             "field_type": "text"
         },
         {
@@ -182,7 +204,7 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": "nullable|string",
-            "sort": 14,
+            "sort": 16,
             "field_type": "text"
         },
         {
@@ -193,7 +215,7 @@
             "user_viewable": false,
             "user_editable": false,
             "rules": "required|integer",
-            "sort": 15,
+            "sort": 17,
             "field_type": "text"
         }
     ]

--- a/arma/arma_reforger/egg-pterodactyl-arma-reforger.json
+++ b/arma/arma_reforger/egg-pterodactyl-arma-reforger.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2024-07-03T21:46:20-07:00",
+    "exported_at": "2024-11-28T14:47:08-08:00",
     "name": "Arma Reforger",
     "author": "red_thirten@yahoo.com",
     "description": "Experience authentic Cold War combat and join friends in the struggle for a sprawling, 51 km\u00b2 mid-Atlantic island \u2014 or take on the role of Game Master and create your very own scenarios for others to enjoy.",
@@ -24,12 +24,32 @@
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/bash\r\n\r\n## File: Pterodactyl Arma Reforger Egg - egg-pterodactyl-arma-reforger.json\r\n## Author: David Wolfe (Red-Thirten)\r\n## Date: 2024\/07\/03\r\n## License: MIT License\r\n## Image to install with is 'ghcr.io\/parkervcp\/installers:debian'\r\n\r\n## Download and install SteamCMD\r\nexport HOME=\/mnt\/server\r\ncd \/tmp\r\nmkdir -p $HOME\/steamcmd $HOME\/steamapps\r\ncurl -sSL -o steamcmd.tar.gz https:\/\/steamcdn-a.akamaihd.net\/client\/installer\/steamcmd_linux.tar.gz\r\ntar -xzvf steamcmd.tar.gz -C $HOME\/steamcmd\r\ncd $HOME\/steamcmd\r\n\r\n# SteamCMD fails otherwise for some reason, even running as root.\r\nchown -R root:root \/mnt\r\n\r\n# Install\/Verify game server using SteamCMD\r\n.\/steamcmd.sh +force_install_dir $HOME +login anonymous $( [[ \"${WINDOWS_INSTALL}\" == \"1\" ]] && printf %s '+@sSteamCmdForcePlatformType windows' ) +app_update ${SRCDS_APPID} +app_update 1007 $( [[ -z ${SRCDS_BETAID} ]] || printf %s \"-beta ${SRCDS_BETAID}\" ) $( [[ -z ${SRCDS_BETAPASS} ]] || printf %s \"-betapassword ${SRCDS_BETAPASS}\" ) validate +quit\r\n\r\n# Set up 32 and 64 bit libraries\r\nmkdir -p \/mnt\/server\/.steam\/sdk{32,64}\r\ncp -v linux32\/steamclient.so \/mnt\/server\/.steam\/sdk32\/steamclient.so\r\ncp -v linux64\/steamclient.so \/mnt\/server\/.steam\/sdk64\/steamclient.so\r\n\r\n## Arma Reforger setup\r\n# Check for successful installation\r\nif [[ ! -f $HOME\/ArmaReforgerServer ]]; then\r\n    echo -e \"\\n\\nSteamCMD failed to install the Arma Reforger Dedicated Server!\"\r\n    echo -e \"\\tTry reinstalling the server again.\\n\"\r\n    exit 1\r\nfi\r\n\r\nmkdir -p $HOME\/profile $HOME\/tmp\r\n\r\necho -e 'Creating default \"config.json\" configuration file...'\r\ncat > $HOME\/config.json << EOF\r\n{\r\n\t\"bindAddress\": \"0.0.0.0\",\r\n\t\"bindPort\": ${SERVER_PORT},\r\n\t\"publicAddress\": \"${SERVER_IP}\",\r\n\t\"publicPort\": ${SERVER_PORT},\r\n\t\"game\": {\r\n\t\t\"name\": \"${SERVER_NAME}\",\r\n\t\t\"password\": \"${SERVER_PASS}\",\r\n\t\t\"passwordAdmin\": \"${ADMIN_PASS}\",\r\n\t\t\"admins\" : [],\r\n\t\t\"scenarioId\": \"${SCENARIO_ID}\",\r\n\t\t\"maxPlayers\": ${MAX_PLAYERS},\r\n\t\t\"visible\": ${VISIBLE},\r\n\t\t\"gameProperties\": {\r\n\t\t\t\"serverMaxViewDistance\": 2500,\r\n\t\t\t\"serverMinGrassDistance\": 50,\r\n\t\t\t\"networkViewDistance\": 1000,\r\n\t\t\t\"disableThirdPerson\": ${DISABLE_THIRD},\r\n\t\t\t\"fastValidation\": true,\r\n\t\t\t\"battlEye\": ${BATTLEYE},\r\n\t\t\t\"VONDisableUI\": false,\r\n\t\t\t\"VONDisableDirectSpeechUI\": false\r\n\t\t},\r\n\t\t\"mods\": []\r\n\t}\r\n}\r\nEOF\r\n\r\necho -e \"\\nArma Reforger Dedicated Server successfully installed!\\n\"",
+            "script": "#!\/bin\/bash\r\n\r\n## File: Pterodactyl Arma Reforger Egg - egg-pterodactyl-arma-reforger.json\r\n## Author: David Wolfe (Red-Thirten)\r\n## Date: 2024\/11\/28\r\n## License: MIT License\r\n## Image to install with is 'ghcr.io\/parkervcp\/installers:debian'\r\n\r\n# Check for valid Steam credentials to download Arma Reforger with (requires valid Steam account)\r\nif [[ \"${STEAM_USER}\" == \"\" ]] || [[ \"${STEAM_USER}\" == \"anonymous\" ]] || [[ \"${STEAM_PASS}\" == \"\" ]]; then\r\n    echo -e \"INSTALLATION ERROR: A valid REAL Steam account is required to download the Arma Reforger Dedicated Server.\"\r\n    echo -e \"\\t(\\\"anonymous\\\" account cannot be used. Game ownership is not required.)\"\r\n    exit 1\r\nfi\r\n\r\n## Download and install SteamCMD\r\nexport HOME=\/mnt\/server\r\ncd \/tmp\r\nmkdir -p $HOME\/steamcmd $HOME\/steamapps\r\ncurl -sSL -o steamcmd.tar.gz https:\/\/steamcdn-a.akamaihd.net\/client\/installer\/steamcmd_linux.tar.gz\r\ntar -xzvf steamcmd.tar.gz -C $HOME\/steamcmd\r\ncd $HOME\/steamcmd\r\n\r\n# SteamCMD fails otherwise for some reason, even running as root.\r\nchown -R root:root \/mnt\r\n\r\n# Install\/Verify game server using SteamCMD\r\n.\/steamcmd.sh +force_install_dir $HOME \"+login \\\"${STEAM_USER}\\\" \\\"${STEAM_PASS}\\\"\" $( [[ \"${WINDOWS_INSTALL}\" == \"1\" ]] && printf %s '+@sSteamCmdForcePlatformType windows' ) +app_update ${SRCDS_APPID} +app_update 1007 $( [[ -z ${SRCDS_BETAID} ]] || printf %s \"-beta ${SRCDS_BETAID}\" ) $( [[ -z ${SRCDS_BETAPASS} ]] || printf %s \"-betapassword ${SRCDS_BETAPASS}\" ) validate +quit\r\n\r\n# Set up 32 and 64 bit libraries\r\nmkdir -p \/mnt\/server\/.steam\/sdk{32,64}\r\ncp -v linux32\/steamclient.so \/mnt\/server\/.steam\/sdk32\/steamclient.so\r\ncp -v linux64\/steamclient.so \/mnt\/server\/.steam\/sdk64\/steamclient.so\r\n\r\n## Arma Reforger setup\r\n# Check for successful installation\r\nif [[ ! -f $HOME\/ArmaReforgerServer ]]; then\r\n    echo -e \"\\n\\nSteamCMD failed to install the Arma Reforger Dedicated Server!\"\r\n    echo -e \"\\tTry reinstalling the server again.\\n\"\r\n    exit 1\r\nfi\r\n\r\nmkdir -p $HOME\/profile $HOME\/tmp\r\n\r\necho -e 'Creating default \"config.json\" configuration file...'\r\ncat > $HOME\/config.json << EOF\r\n{\r\n\t\"bindAddress\": \"0.0.0.0\",\r\n\t\"bindPort\": ${SERVER_PORT},\r\n\t\"publicAddress\": \"${SERVER_IP}\",\r\n\t\"publicPort\": ${SERVER_PORT},\r\n\t\"game\": {\r\n\t\t\"name\": \"${SERVER_NAME}\",\r\n\t\t\"password\": \"${SERVER_PASS}\",\r\n\t\t\"passwordAdmin\": \"${ADMIN_PASS}\",\r\n\t\t\"admins\" : [],\r\n\t\t\"scenarioId\": \"${SCENARIO_ID}\",\r\n\t\t\"maxPlayers\": ${MAX_PLAYERS},\r\n\t\t\"visible\": ${VISIBLE},\r\n\t\t\"gameProperties\": {\r\n\t\t\t\"serverMaxViewDistance\": 2500,\r\n\t\t\t\"serverMinGrassDistance\": 50,\r\n\t\t\t\"networkViewDistance\": 1000,\r\n\t\t\t\"disableThirdPerson\": ${DISABLE_THIRD},\r\n\t\t\t\"fastValidation\": true,\r\n\t\t\t\"battlEye\": ${BATTLEYE},\r\n\t\t\t\"VONDisableUI\": false,\r\n\t\t\t\"VONDisableDirectSpeechUI\": false\r\n\t\t},\r\n\t\t\"mods\": []\r\n\t}\r\n}\r\nEOF\r\n\r\necho -e \"\\nArma Reforger Dedicated Server successfully installed!\\n\"",
             "container": "ghcr.io\/parkervcp\/installers:debian",
             "entrypoint": "\/bin\/bash"
         }
     },
     "variables": [
+        {
+            "name": "[REQUIRED] Steam Username",
+            "description": "Used for installation and updates. Account does not need to own Arma Reforger, but MUST BE a VALID Steam account (anonymous login cannot be used). For security reasons it is recommended that you create a new Steam account just for your dedicated servers. *This info is not visible to the server owner.*",
+            "env_variable": "STEAM_USER",
+            "default_value": "",
+            "user_viewable": false,
+            "user_editable": false,
+            "rules": "required|string",
+            "field_type": "text"
+        },
+        {
+            "name": "[REQUIRED] Steam Password",
+            "description": "Used for installation and updates. Steam Guard MUST be completely TURNED OFF for install to complete successfully. *This info is not visible to the server owner, BUT IS stored in PLAIN TEXT. It is NOT advised to use a personal account; best to use a dummy account.*",
+            "env_variable": "STEAM_PASS",
+            "default_value": "",
+            "user_viewable": false,
+            "user_editable": false,
+            "rules": "required|string",
+            "field_type": "text"
+        },
         {
             "name": "Automatic Updates",
             "description": "Quickly checks for any server or mod updates on startup, and updates if necessary.",


### PR DESCRIPTION
# Description

- Fixes the "Invalid platform" SteamCMD installation error by forcing the use of a valid Steam account. It is currently unclear at this time if this is now an intended requirement by the Bohemia Interactive devs or not (eg. making it mirror Arma 3's similar requirement).
- Updated the README to reflect this change of requirements.

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?

<!-- If this is an egg update fill these out -->

* [x] You verify that the start command applied does not use a shell script
* [x] The egg was exported from the panel