### PR TITLE
Fixed Icarus Crash Issue #121

### DIFF
--- a/icarus/README.md
+++ b/icarus/README.md
@@ -40,7 +40,7 @@ ___
 
 ### Server Ports
 
-- Default server ports are listed below, but all three ports can be changed freely.
+- Default server ports are listed below, but all ports can be changed freely.
 - Clients connect via the server list in game.
 
 | Port    | Default | Protocol |
@@ -54,7 +54,7 @@ ___
 
 |           | Recommended  | Extra info  |
 |-----------|--------------|-------------|
-| Processor | Recent x86/64 (AMD/Intel) processor. No 32 bit or ARM support. | Unsubstantiated reports say that RCON uses significantly more CPU when enabled, but I have not been able to replicate myself. |
+| Processor | Recent x86/64 (AMD/Intel) processor. No 32 bit or ARM support. | |
 | RAM       |  8-16 GB     |
 | Storage   |  14 GB (or more, depending on save size or frequency) |
 

--- a/icarus/egg-icarus--dedicated.json
+++ b/icarus/egg-icarus--dedicated.json
@@ -1,10 +1,10 @@
 {
-    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
+    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2025-02-05T17:40:05+01:00",
+    "exported_at": "2024-06-01T00:03:56+00:00",
     "name": "Icarus-Dedicated",
     "author": "bolverblitz@ebg.pw",
     "uuid": "7f2f0676-3d0c-457f-a3aa-b2af40966698",
@@ -19,7 +19,7 @@
     "startup": "wine64 .\/Icarus\/Binaries\/Win64\/IcarusServer-Win64-Shipping.exe -Log -SteamServerName=${SERVER_NAME} -PORT=\"${SERVER_PORT}\" -QueryPort=\"${QUERY_PORT}\"",
     "config": {
         "files": "{}",
-        "startup": "{\r\n    \"done\": \"Display: Game Engine Initialized.\"\r\n}",
+        "startup": "{\r\n    \"done\": \"(Engine Initialization) Total time:\"\r\n}",
         "logs": "{}",
         "stop": "^C"
     },
@@ -39,6 +39,7 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|integer|between:1024,65536",
+            "sort": null,
             "field_type": "text"
         },
         {
@@ -49,6 +50,7 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|string|max:32",
+            "sort": null,
             "field_type": "text"
         },
         {
@@ -59,6 +61,18 @@
             "user_viewable": false,
             "user_editable": false,
             "rules": "required|boolean",
+            "sort": null,
+            "field_type": "text"
+        },
+        {
+            "name": "WINETRICKS_RUN",
+            "description": "Run installs on software that is required by the server",
+            "env_variable": "WINETRICKS_RUN",
+            "default_value": "vcrun2019 corefonts",
+            "user_viewable": false,
+            "user_editable": false,
+            "rules": "required|string|in:vcrun2019 corefonts",
+            "sort": null,
             "field_type": "text"
         },
         {
@@ -69,6 +83,7 @@
             "user_viewable": false,
             "user_editable": false,
             "rules": "required|string|in:2089300",
+            "sort": null,
             "field_type": "text"
         },
         {
@@ -79,6 +94,7 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|boolean",
+            "sort": null,
             "field_type": "text"
         },
         {
@@ -89,6 +105,7 @@
             "user_viewable": false,
             "user_editable": false,
             "rules": "required|string|max:20",
+            "sort": null,
             "field_type": "text"
         },
         {
@@ -99,6 +116,7 @@
             "user_viewable": false,
             "user_editable": false,
             "rules": "required|string|max:20",
+            "sort": null,
             "field_type": "text"
         },
         {
@@ -109,6 +127,7 @@
             "user_viewable": false,
             "user_editable": false,
             "rules": "required|string|in:win64",
+            "sort": null,
             "field_type": "text"
         }
     ]

--- a/icarus/egg-icarus--dedicated.json
+++ b/icarus/egg-icarus--dedicated.json
@@ -1,10 +1,10 @@
 {
-    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
+    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2024-06-01T00:03:56+00:00",
+    "exported_at": "2025-02-05T17:40:05+01:00",
     "name": "Icarus-Dedicated",
     "author": "bolverblitz@ebg.pw",
     "uuid": "7f2f0676-3d0c-457f-a3aa-b2af40966698",
@@ -19,7 +19,7 @@
     "startup": "wine64 .\/Icarus\/Binaries\/Win64\/IcarusServer-Win64-Shipping.exe -Log -SteamServerName=${SERVER_NAME} -PORT=\"${SERVER_PORT}\" -QueryPort=\"${QUERY_PORT}\"",
     "config": {
         "files": "{}",
-        "startup": "{\r\n    \"done\": \"(Engine Initialization) Total time:\"\r\n}",
+        "startup": "{\r\n    \"done\": \"Display: Game Engine Initialized.\"\r\n}",
         "logs": "{}",
         "stop": "^C"
     },
@@ -39,7 +39,6 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|integer|between:1024,65536",
-            "sort": null,
             "field_type": "text"
         },
         {
@@ -50,7 +49,6 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|string|max:32",
-            "sort": null,
             "field_type": "text"
         },
         {
@@ -61,18 +59,6 @@
             "user_viewable": false,
             "user_editable": false,
             "rules": "required|boolean",
-            "sort": null,
-            "field_type": "text"
-        },
-        {
-            "name": "WINETRICKS_RUN",
-            "description": "Run installs on software that is required by the server",
-            "env_variable": "WINETRICKS_RUN",
-            "default_value": "vcrun2019 corefonts",
-            "user_viewable": false,
-            "user_editable": false,
-            "rules": "required|string|in:vcrun2019 corefonts",
-            "sort": null,
             "field_type": "text"
         },
         {
@@ -83,7 +69,6 @@
             "user_viewable": false,
             "user_editable": false,
             "rules": "required|string|in:2089300",
-            "sort": null,
             "field_type": "text"
         },
         {
@@ -94,7 +79,6 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|boolean",
-            "sort": null,
             "field_type": "text"
         },
         {
@@ -105,7 +89,6 @@
             "user_viewable": false,
             "user_editable": false,
             "rules": "required|string|max:20",
-            "sort": null,
             "field_type": "text"
         },
         {
@@ -116,7 +99,6 @@
             "user_viewable": false,
             "user_editable": false,
             "rules": "required|string|max:20",
-            "sort": null,
             "field_type": "text"
         },
         {
@@ -127,7 +109,6 @@
             "user_viewable": false,
             "user_editable": false,
             "rules": "required|string|in:win64",
-            "sort": null,
             "field_type": "text"
         }
     ]

--- a/icarus/egg-pterodactyl-icarus--dedicated.json
+++ b/icarus/egg-pterodactyl-icarus--dedicated.json
@@ -1,10 +1,10 @@
 {
-    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
+    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
-        "update_url": null,
-        "version": "PTDL_v2"
+        "version": "PTDL_v2",
+        "update_url": null
     },
-    "exported_at": "2024-06-01T00:03:56+00:00",
+    "exported_at": "2025-02-05T17:40:05+01:00",
     "name": "Icarus-Dedicated",
     "author": "bolverblitz@ebg.pw",
     "description": "Icarus is a survival game that with dedicated servers as a public beta",
@@ -12,21 +12,21 @@
         "steam_disk_space"
     ],
     "docker_images": {
-        "Wine Staging": "ghcr.io/parkervcp/yolks:wine_latest"
+        "Wine Staging": "ghcr.io\/parkervcp\/yolks:wine_latest"
     },
     "file_denylist": [],
-    "startup": "wine64 ./Icarus/Binaries/Win64/IcarusServer-Win64-Shipping.exe -Log -SteamServerName=${SERVER_NAME} -PORT=\"${SERVER_PORT}\" -QueryPort=\"${QUERY_PORT}\"",
+    "startup": "wine64 .\/Icarus\/Binaries\/Win64\/IcarusServer-Win64-Shipping.exe -Log -SteamServerName=${SERVER_NAME} -PORT=\"${SERVER_PORT}\" -QueryPort=\"${QUERY_PORT}\"",
     "config": {
         "files": "{}",
+        "startup": "{\r\n    \"done\": \"Display: Game Engine Initialized.\"\r\n}",
         "logs": "{}",
-        "startup": "{\r\n    \"done\": \"(Engine Initialization) Total time:\"\r\n}",
         "stop": "^C"
     },
     "scripts": {
         "installation": {
-            "container": "ghcr.io/parkervcp/installers:debian",
-            "entrypoint": "/bin/bash",
-            "script": "#!/bin/bash\r\n\r\n## License: MIT License\r\n## Image to install with is 'ghcr.io/parkervcp/installers:debian'\r\n\r\nif [[ \"${STEAM_USER}\" == \"\" ]] || [[ \"${STEAM_PASS}\" == \"\" ]]; then\r\n    echo -e \"steam user is not set.\\n\"\r\n    echo -e \"Using anonymous user.\\n\"\r\n    STEAM_USER=anonymous\r\n    STEAM_PASS=\"\"\r\n    STEAM_AUTH=\"\"\r\nelse\r\n    echo -e \"user set to ${STEAM_USER}\"\r\nfi\r\n\r\n## download and install steamcmd\r\ncd /tmp\r\nmkdir -p /mnt/server/steamcmd\r\ncurl -sSL -o steamcmd.tar.gz https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz\r\ntar -xzvf steamcmd.tar.gz -C /mnt/server/steamcmd\r\nmkdir -p /mnt/server/steamapps # Fix steamcmd disk write error when this folder is missing\r\ncd /mnt/server/steamcmd\r\n\r\n# SteamCMD fails otherwise for some reason, even running as root.\r\n# This is changed at the end of the install process anyways.\r\nchown -R root:root /mnt\r\nexport HOME=/mnt/server\r\n\r\n## install game using steamcmd\r\n./steamcmd.sh +force_install_dir /mnt/server +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} $( [[ \"${WINDOWS_INSTALL}\" == \"1\" ]] \u0026\u0026 printf %s '+@sSteamCmdForcePlatformType windows' ) +app_update ${SRCDS_APPID} validate +quit\r\n\r\n## set up 32 bit libraries\r\nmkdir -p /mnt/server/.steam/sdk32\r\ncp -v linux32/steamclient.so ../.steam/sdk32/steamclient.so\r\n\r\n## set up 64 bit libraries\r\nmkdir -p /mnt/server/.steam/sdk64\r\ncp -v linux64/steamclient.so ../.steam/sdk64/steamclient.so\r\n\r\nFILE=/mnt/server/Icarus/Saved/Config/ServerSettings.ini\r\nif [ -f \"$FILE\" ]; then\r\n    echo \"Config already exist skipping\"\r\nelse \r\n    echo \"Config does not yet exist, making one\"\r\n    mkdir -p /mnt/server/Icarus/Saved/Config/\r\n    cd /mnt/server/Icarus/Saved/Config/\r\n    curl -sSL -o ServerSettings.ini https://raw.githubusercontent.com/RocketWerkz/IcarusDedicatedServer/main/ServerSettings.ini\r\nfi\r\n\r\n## install end\r\necho \"-----------------------------------------\"\r\necho \"Installation completed...\"\r\necho \"-----------------------------------------\""
+            "script": "#!\/bin\/bash\r\n\r\n## License: MIT License\r\n## Image to install with is 'ghcr.io\/parkervcp\/installers:debian'\r\n\r\nif [[ \"${STEAM_USER}\" == \"\" ]] || [[ \"${STEAM_PASS}\" == \"\" ]]; then\r\n    echo -e \"steam user is not set.\\n\"\r\n    echo -e \"Using anonymous user.\\n\"\r\n    STEAM_USER=anonymous\r\n    STEAM_PASS=\"\"\r\n    STEAM_AUTH=\"\"\r\nelse\r\n    echo -e \"user set to ${STEAM_USER}\"\r\nfi\r\n\r\n## download and install steamcmd\r\ncd \/tmp\r\nmkdir -p \/mnt\/server\/steamcmd\r\ncurl -sSL -o steamcmd.tar.gz https:\/\/steamcdn-a.akamaihd.net\/client\/installer\/steamcmd_linux.tar.gz\r\ntar -xzvf steamcmd.tar.gz -C \/mnt\/server\/steamcmd\r\nmkdir -p \/mnt\/server\/steamapps # Fix steamcmd disk write error when this folder is missing\r\ncd \/mnt\/server\/steamcmd\r\n\r\n# SteamCMD fails otherwise for some reason, even running as root.\r\n# This is changed at the end of the install process anyways.\r\nchown -R root:root \/mnt\r\nexport HOME=\/mnt\/server\r\n\r\n## install game using steamcmd\r\n.\/steamcmd.sh +force_install_dir \/mnt\/server +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} $( [[ \"${WINDOWS_INSTALL}\" == \"1\" ]] && printf %s '+@sSteamCmdForcePlatformType windows' ) +app_update ${SRCDS_APPID} validate +quit\r\n\r\n## set up 32 bit libraries\r\nmkdir -p \/mnt\/server\/.steam\/sdk32\r\ncp -v linux32\/steamclient.so ..\/.steam\/sdk32\/steamclient.so\r\n\r\n## set up 64 bit libraries\r\nmkdir -p \/mnt\/server\/.steam\/sdk64\r\ncp -v linux64\/steamclient.so ..\/.steam\/sdk64\/steamclient.so\r\n\r\nFILE=\/mnt\/server\/Icarus\/Saved\/Config\/ServerSettings.ini\r\nif [ -f \"$FILE\" ]; then\r\n    echo \"Config already exist skipping\"\r\nelse \r\n    echo \"Config does not yet exist, making one\"\r\n    mkdir -p \/mnt\/server\/Icarus\/Saved\/Config\/\r\n    cd \/mnt\/server\/Icarus\/Saved\/Config\/\r\n    curl -sSL -o ServerSettings.ini https:\/\/raw.githubusercontent.com\/RocketWerkz\/IcarusDedicatedServer\/main\/ServerSettings.ini\r\nfi\r\n\r\n## install end\r\necho \"-----------------------------------------\"\r\necho \"Installation completed...\"\r\necho \"-----------------------------------------\"",
+            "container": "ghcr.io\/parkervcp\/installers:debian",
+            "entrypoint": "\/bin\/bash"
         }
     },
     "variables": [
@@ -61,18 +61,8 @@
             "field_type": "text"
         },
         {
-            "name": "WINETRICKS_RUN",
-            "description": "Run installs on software that is required by the server",
-            "env_variable": "WINETRICKS_RUN",
-            "default_value": "vcrun2019 corefonts",
-            "user_viewable": false,
-            "user_editable": false,
-            "rules": "required|string|in:vcrun2019 corefonts",
-            "field_type": "text"
-        },
-        {
             "name": "SRCDS_APPID",
-            "description": "steam app id found here - https://developer.valvesoftware.com/wiki/Dedicated_Servers_List",
+            "description": "steam app id found here - https:\/\/developer.valvesoftware.com\/wiki\/Dedicated_Servers_List",
             "env_variable": "SRCDS_APPID",
             "default_value": "2089300",
             "user_viewable": false,
@@ -104,7 +94,7 @@
             "name": "WINEPATH",
             "description": "",
             "env_variable": "WINEPATH",
-            "default_value": "/home/container",
+            "default_value": "\/home\/container",
             "user_viewable": false,
             "user_editable": false,
             "rules": "required|string|max:20",


### PR DESCRIPTION
# Description

The egg crashed on startup when importing a VC DLL, removing vcrun2019 will stop the game from loading this file and removing winetricks all together makes it start much faster

## Checklist for all submissions

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you tested and reviewed your changes with confidence that everything works?
* [X] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:
* [X] You verify that the start command applied does not use a shell script
  * [X] If some script is needed then it is part of a current yolk or a PR to add one
* [X] The egg was exported from the panel
