### PR TITLE
Fix Port parameter for Abiotic Factor

### DIFF
--- a/abiotic_factor/egg-abiotic-factor.json
+++ b/abiotic_factor/egg-abiotic-factor.json
@@ -1,10 +1,10 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
-        "version": "PTDL_v2",
+        "version": "PLCN_v1",
         "update_url": null
     },
-    "exported_at": "2024-06-01T00:03:47+00:00",
+    "exported_at": "2025-02-14T08:08:55+00:00",
     "name": "Abiotic Factor",
     "author": "git@robsti.dev",
     "uuid": "e4316a24-7f8a-458a-a462-57d8f3f4b0cd",
@@ -38,9 +38,11 @@
             "default_value": "2857200",
             "user_viewable": false,
             "user_editable": false,
-            "rules": "required|numeric",
-            "sort": null,
-            "field_type": "text"
+            "rules": [
+                "required",
+                "numeric"
+            ],
+            "sort": 1
         },
         {
             "name": "[STEAM] Auto Update",
@@ -49,9 +51,11 @@
             "default_value": "1",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|boolean",
-            "sort": null,
-            "field_type": "text"
+            "rules": [
+                "required",
+                "boolean"
+            ],
+            "sort": 2
         },
         {
             "name": "[SERVER] Server Name",
@@ -60,9 +64,12 @@
             "default_value": "A Pelican Hosted Server",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string|max:64",
-            "sort": null,
-            "field_type": "text"
+            "rules": [
+                "required",
+                "string",
+                "max:64"
+            ],
+            "sort": 3
         },
         {
             "name": "[STEAM] WINDOWS_INSTALL",
@@ -71,9 +78,12 @@
             "default_value": "1",
             "user_viewable": false,
             "user_editable": false,
-            "rules": "required|boolean|in:1",
-            "sort": null,
-            "field_type": "text"
+            "rules": [
+                "required",
+                "boolean",
+                "in:1"
+            ],
+            "sort": 4
         },
         {
             "name": "[SERVER] Server Password",
@@ -82,9 +92,12 @@
             "default_value": "",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string|max:30",
-            "sort": null,
-            "field_type": "text"
+            "rules": [
+                "required",
+                "string",
+                "max:30"
+            ],
+            "sort": 5
         },
         {
             "name": "[SERVER] Query Port",
@@ -93,9 +106,11 @@
             "default_value": "27015",
             "user_viewable": true,
             "user_editable": false,
-            "rules": "required|numeric",
-            "sort": null,
-            "field_type": "text"
+            "rules": [
+                "required",
+                "numeric"
+            ],
+            "sort": 6
         },
         {
             "name": "[SERVER] Number of Players",
@@ -104,9 +119,12 @@
             "default_value": "6",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|numeric|between:1,32",
-            "sort": null,
-            "field_type": "text"
+            "rules": [
+                "required",
+                "numeric",
+                "between:1,32"
+            ],
+            "sort": 7
         }
     ]
 }

--- a/abiotic_factor/egg-abiotic-factor.json
+++ b/abiotic_factor/egg-abiotic-factor.json
@@ -16,7 +16,7 @@
         "ghcr.io\/parkervcp\/steamcmd:proton": "ghcr.io\/parkervcp\/steamcmd:proton"
     },
     "file_denylist": [],
-    "startup": "cd \/home\/container\/AbioticFactor\/Binaries\/Win64; proton run .\/AbioticFactorServer-Win64-Shipping.exe -log -useperfthreads -NoAsyncLoadingThread -MaxServerPlayers=${NUM_PLAYERS} -PORT=${SERVER_PORT} -QueryPort=${QUERY_PORT} -ServerPassword=\"${SERVER_PASSWORD}\" -SteamServerName=\"${SERVER_NAME}\" & AF_PID=$!; tail -c0 -F \/home\/container\/AbioticFactor\/Saved\/Logs\/AbioticFactor.log --pid=$AF_PID",
+    "startup": "cd \/home\/container\/AbioticFactor\/Binaries\/Win64; proton run .\/AbioticFactorServer-Win64-Shipping.exe -log -useperfthreads -NoAsyncLoadingThread -MaxServerPlayers=${NUM_PLAYERS} -Port=${SERVER_PORT} -QueryPort=${QUERY_PORT} -ServerPassword=\"${SERVER_PASSWORD}\" -SteamServerName=\"${SERVER_NAME}\" & AF_PID=$!; tail -c0 -F \/home\/container\/AbioticFactor\/Saved\/Logs\/AbioticFactor.log --pid=$AF_PID",
     "config": {
         "files": "{}",
         "startup": "{\r\n    \"done\": \"LogInit: Display: Engine is initialized.\"\r\n}",

--- a/abiotic_factor/egg-abiotic-factor.json
+++ b/abiotic_factor/egg-abiotic-factor.json
@@ -4,7 +4,7 @@
         "version": "PLCN_v1",
         "update_url": null
     },
-    "exported_at": "2025-02-14T08:08:55+00:00",
+    "exported_at": "2025-02-16T11:00:13+00:00",
     "name": "Abiotic Factor",
     "author": "git@robsti.dev",
     "uuid": "e4316a24-7f8a-458a-a462-57d8f3f4b0cd",
@@ -16,7 +16,7 @@
         "ghcr.io\/parkervcp\/steamcmd:proton": "ghcr.io\/parkervcp\/steamcmd:proton"
     },
     "file_denylist": [],
-    "startup": "cd \/home\/container\/AbioticFactor\/Binaries\/Win64; proton run .\/AbioticFactorServer-Win64-Shipping.exe -log -useperfthreads -NoAsyncLoadingThread -MaxServerPlayers=${NUM_PLAYERS} -Port=${SERVER_PORT} -QueryPort=${QUERY_PORT} -ServerPassword=\"${SERVER_PASSWORD}\" -SteamServerName=\"${SERVER_NAME}\" & AF_PID=$!; tail -c0 -F \/home\/container\/AbioticFactor\/Saved\/Logs\/AbioticFactor.log --pid=$AF_PID",
+    "startup": "cd \/home\/container\/AbioticFactor\/Binaries\/Win64; proton run .\/AbioticFactorServer-Win64-Shipping.exe -log -useperfthreads -NoAsyncLoadingThread -MaxServerPlayers={{NUM_PLAYERS}} -Port={{SERVER_PORT}} -QueryPort={{QUERY_PORT}} -ServerPassword=\"{{SERVER_PASSWORD}}\" -SteamServerName=\"{{SERVER_NAME}}\" & AF_PID=$!; tail -c0 -F \/home\/container\/AbioticFactor\/Saved\/Logs\/AbioticFactor.log --pid=$AF_PID",
     "config": {
         "files": "{}",
         "startup": "{\r\n    \"done\": \"LogInit: Display: Engine is initialized.\"\r\n}",
@@ -32,6 +32,7 @@
     },
     "variables": [
         {
+            "sort": 1,
             "name": "[STEAM] SRCDS_APPID",
             "description": "Steam App ID",
             "env_variable": "SRCDS_APPID",
@@ -40,11 +41,12 @@
             "user_editable": false,
             "rules": [
                 "required",
-                "numeric"
-            ],
-            "sort": 1
+                "numeric",
+                "in:2857200"
+            ]
         },
         {
+            "sort": 2,
             "name": "[STEAM] Auto Update",
             "description": "Should Auto Update",
             "env_variable": "AUTO_UPDATE",
@@ -54,10 +56,10 @@
             "rules": [
                 "required",
                 "boolean"
-            ],
-            "sort": 2
+            ]
         },
         {
+            "sort": 3,
             "name": "[SERVER] Server Name",
             "description": "Name of the server",
             "env_variable": "SERVER_NAME",
@@ -68,10 +70,10 @@
                 "required",
                 "string",
                 "max:64"
-            ],
-            "sort": 3
+            ]
         },
         {
+            "sort": 4,
             "name": "[STEAM] WINDOWS_INSTALL",
             "description": "",
             "env_variable": "WINDOWS_INSTALL",
@@ -82,10 +84,10 @@
                 "required",
                 "boolean",
                 "in:1"
-            ],
-            "sort": 4
+            ]
         },
         {
+            "sort": 5,
             "name": "[SERVER] Server Password",
             "description": "Server access password",
             "env_variable": "SERVER_PASSWORD",
@@ -96,10 +98,10 @@
                 "required",
                 "string",
                 "max:30"
-            ],
-            "sort": 5
+            ]
         },
         {
+            "sort": 6,
             "name": "[SERVER] Query Port",
             "description": "Steam query port",
             "env_variable": "QUERY_PORT",
@@ -109,10 +111,10 @@
             "rules": [
                 "required",
                 "numeric"
-            ],
-            "sort": 6
+            ]
         },
         {
+            "sort": 7,
             "name": "[SERVER] Number of Players",
             "description": "Number of allowed player connections",
             "env_variable": "NUM_PLAYERS",
@@ -123,8 +125,7 @@
                 "required",
                 "numeric",
                 "between:1,32"
-            ],
-            "sort": 7
+            ]
         }
     ]
 }

--- a/abiotic_factor/egg-pterodactyl-abiotic-factor.json
+++ b/abiotic_factor/egg-pterodactyl-abiotic-factor.json
@@ -1,32 +1,32 @@
 {
-    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
+    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
-        "update_url": null,
-        "version": "PTDL_v2"
+        "version": "PTDL_v2",
+        "update_url": null
     },
-    "exported_at": "2024-06-01T00:03:47+00:00",
+    "exported_at": "2025-02-16T11:00:13+00:00",
     "name": "Abiotic Factor",
     "author": "git@robsti.dev",
-    "description": "Abiotic Factor is a survival crafting experience for 1-6 players set in the depths of an underground research facility. Caught between paranormal containment failure, a military crusade, and chaos from a dozen realms, the world’s greatest minds must survive against the universe’s biggest threats.",
+    "description": "Abiotic Factor is a survival crafting experience for 1-6 players set in the depths of an underground research facility. Caught between paranormal containment failure, a military crusade, and chaos from a dozen realms, the world\u2019s greatest minds must survive against the universe\u2019s biggest threats.",
     "features": [
         "steam_disk_space"
     ],
     "docker_images": {
-        "ghcr.io/parkervcp/steamcmd:proton": "ghcr.io/parkervcp/steamcmd:proton"
+        "ghcr.io\/parkervcp\/steamcmd:proton": "ghcr.io\/parkervcp\/steamcmd:proton"
     },
     "file_denylist": [],
-    "startup": "cd /home/container/AbioticFactor/Binaries/Win64; proton run ./AbioticFactorServer-Win64-Shipping.exe -log -useperfthreads -NoAsyncLoadingThread -MaxServerPlayers=${NUM_PLAYERS} -PORT=${SERVER_PORT} -QueryPort=${QUERY_PORT} -ServerPassword=\"${SERVER_PASSWORD}\" -SteamServerName=\"${SERVER_NAME}\" \u0026 AF_PID=$!; tail -c0 -F /home/container/AbioticFactor/Saved/Logs/AbioticFactor.log --pid=$AF_PID",
+    "startup": "cd \/home\/container\/AbioticFactor\/Binaries\/Win64; proton run .\/AbioticFactorServer-Win64-Shipping.exe -log -useperfthreads -NoAsyncLoadingThread -MaxServerPlayers={{NUM_PLAYERS}} -Port={{SERVER_PORT}} -QueryPort={{QUERY_PORT}} -ServerPassword=\"{{SERVER_PASSWORD}}\" -SteamServerName=\"{{SERVER_NAME}}\" & AF_PID=$!; tail -c0 -F \/home\/container\/AbioticFactor\/Saved\/Logs\/AbioticFactor.log --pid=$AF_PID",
     "config": {
         "files": "{}",
-        "logs": "{}",
         "startup": "{\r\n    \"done\": \"LogInit: Display: Engine is initialized.\"\r\n}",
+        "logs": "{}",
         "stop": "^C"
     },
     "scripts": {
         "installation": {
-            "container": "ghcr.io/parkervcp/installers:debian",
-            "entrypoint": "bash",
-            "script": "#!/bin/bash\r\n# steamcmd Base Installation Script\r\n#\r\n# Server Files: /mnt/server\r\n# Image to install with is 'ghcr.io/parkervcp/installers:debian'\r\n\r\n##\r\n#\r\n# Variables\r\n# STEAM_USER, STEAM_PASS, STEAM_AUTH - Steam user setup. If a user has 2fa enabled it will most likely fail due to timeout. Leave blank for anon install.\r\n# WINDOWS_INSTALL - if it's a windows server you want to install set to 1\r\n# SRCDS_APPID - steam app id found here - https://developer.valvesoftware.com/wiki/Dedicated_Servers_List\r\n# SRCDS_BETAID - beta branch of a steam app. Leave blank to install normal branch\r\n# SRCDS_BETAPASS - password for a beta branch should one be required during private or closed testing phases.. Leave blank for no password.\r\n# INSTALL_FLAGS - Any additional SteamCMD  flags to pass during install.. Keep in mind that steamcmd auto update process in the docker image might overwrite or ignore these when it performs update on server boot.\r\n# AUTO_UPDATE - Adding this variable to the egg allows disabling or enabling automated updates on boot. Boolean value. 0 to disable and 1 to enable.\r\n#\r\n ##\r\n\r\n# Install packages. Default packages below are not required if using our existing install image thus speeding up the install process.\r\n#apt -y update\r\n#apt -y --no-install-recommends install curl lib32gcc-s1 ca-certificates\r\n\r\n## just in case someone removed the defaults.\r\nif [[ \"${STEAM_USER}\" == \"\" ]] || [[ \"${STEAM_PASS}\" == \"\" ]]; then\r\n    echo -e \"steam user is not set.\\n\"\r\n    echo -e \"Using anonymous user.\\n\"\r\n    STEAM_USER=anonymous\r\n    STEAM_PASS=\"\"\r\n    STEAM_AUTH=\"\"\r\nelse\r\n    echo -e \"user set to ${STEAM_USER}\"\r\nfi\r\n\r\n## download and install steamcmd\r\ncd /tmp\r\nmkdir -p /mnt/server/steamcmd\r\ncurl -sSL -o steamcmd.tar.gz https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz\r\ntar -xzvf steamcmd.tar.gz -C /mnt/server/steamcmd\r\nmkdir -p /mnt/server/steamapps # Fix steamcmd disk write error when this folder is missing\r\ncd /mnt/server/steamcmd\r\n\r\n# SteamCMD fails otherwise for some reason, even running as root.\r\n# This is changed at the end of the install process anyways.\r\nchown -R root:root /mnt\r\nexport HOME=/mnt/server\r\n\r\n## install game using steamcmd\r\n./steamcmd.sh +force_install_dir /mnt/server +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} $( [[ \"${WINDOWS_INSTALL}\" == \"1\" ]] \u0026\u0026 printf %s '+@sSteamCmdForcePlatformType windows' ) +app_update ${SRCDS_APPID} $( [[ -z ${SRCDS_BETAID} ]] || printf %s \"-beta ${SRCDS_BETAID}\" ) $( [[ -z ${SRCDS_BETAPASS} ]] || printf %s \"-betapassword ${SRCDS_BETAPASS}\" ) ${INSTALL_FLAGS} validate +quit ## other flags may be needed depending on install. looking at you cs 1.6\r\n\r\n## set up 32 bit libraries\r\nmkdir -p /mnt/server/.steam/sdk32\r\ncp -v linux32/steamclient.so ../.steam/sdk32/steamclient.so\r\n\r\n## set up 64 bit libraries\r\nmkdir -p /mnt/server/.steam/sdk64\r\ncp -v linux64/steamclient.so ../.steam/sdk64/steamclient.so\r\n\r\n## download the default server settings file\r\nmkdir -p /mnt/server/AbioticFactor/Saved/SaveGames/Server/Worlds/Cascade\r\ncurl -sS -o /mnt/server/AbioticFactor/Saved/SaveGames/Server/Worlds/Cascade/SandboxSettings.ini https://raw.githubusercontent.com/pelican-eggs/steamcmd/main/abiotic_factor/SandboxSettings.ini\r\n\r\n## install end\r\necho \"-----------------------------------------\"\r\necho \"Installation completed...\"\r\necho \"-----------------------------------------\""
+            "script": "#!\/bin\/bash\r\n# steamcmd Base Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\n# Image to install with is 'ghcr.io\/parkervcp\/installers:debian'\r\n\r\n##\r\n#\r\n# Variables\r\n# STEAM_USER, STEAM_PASS, STEAM_AUTH - Steam user setup. If a user has 2fa enabled it will most likely fail due to timeout. Leave blank for anon install.\r\n# WINDOWS_INSTALL - if it's a windows server you want to install set to 1\r\n# SRCDS_APPID - steam app id found here - https:\/\/developer.valvesoftware.com\/wiki\/Dedicated_Servers_List\r\n# SRCDS_BETAID - beta branch of a steam app. Leave blank to install normal branch\r\n# SRCDS_BETAPASS - password for a beta branch should one be required during private or closed testing phases.. Leave blank for no password.\r\n# INSTALL_FLAGS - Any additional SteamCMD  flags to pass during install.. Keep in mind that steamcmd auto update process in the docker image might overwrite or ignore these when it performs update on server boot.\r\n# AUTO_UPDATE - Adding this variable to the egg allows disabling or enabling automated updates on boot. Boolean value. 0 to disable and 1 to enable.\r\n#\r\n ##\r\n\r\n# Install packages. Default packages below are not required if using our existing install image thus speeding up the install process.\r\n#apt -y update\r\n#apt -y --no-install-recommends install curl lib32gcc-s1 ca-certificates\r\n\r\n## just in case someone removed the defaults.\r\nif [[ \"${STEAM_USER}\" == \"\" ]] || [[ \"${STEAM_PASS}\" == \"\" ]]; then\r\n    echo -e \"steam user is not set.\\n\"\r\n    echo -e \"Using anonymous user.\\n\"\r\n    STEAM_USER=anonymous\r\n    STEAM_PASS=\"\"\r\n    STEAM_AUTH=\"\"\r\nelse\r\n    echo -e \"user set to ${STEAM_USER}\"\r\nfi\r\n\r\n## download and install steamcmd\r\ncd \/tmp\r\nmkdir -p \/mnt\/server\/steamcmd\r\ncurl -sSL -o steamcmd.tar.gz https:\/\/steamcdn-a.akamaihd.net\/client\/installer\/steamcmd_linux.tar.gz\r\ntar -xzvf steamcmd.tar.gz -C \/mnt\/server\/steamcmd\r\nmkdir -p \/mnt\/server\/steamapps # Fix steamcmd disk write error when this folder is missing\r\ncd \/mnt\/server\/steamcmd\r\n\r\n# SteamCMD fails otherwise for some reason, even running as root.\r\n# This is changed at the end of the install process anyways.\r\nchown -R root:root \/mnt\r\nexport HOME=\/mnt\/server\r\n\r\n## install game using steamcmd\r\n.\/steamcmd.sh +force_install_dir \/mnt\/server +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} $( [[ \"${WINDOWS_INSTALL}\" == \"1\" ]] && printf %s '+@sSteamCmdForcePlatformType windows' ) +app_update ${SRCDS_APPID} $( [[ -z ${SRCDS_BETAID} ]] || printf %s \"-beta ${SRCDS_BETAID}\" ) $( [[ -z ${SRCDS_BETAPASS} ]] || printf %s \"-betapassword ${SRCDS_BETAPASS}\" ) ${INSTALL_FLAGS} validate +quit ## other flags may be needed depending on install. looking at you cs 1.6\r\n\r\n## set up 32 bit libraries\r\nmkdir -p \/mnt\/server\/.steam\/sdk32\r\ncp -v linux32\/steamclient.so ..\/.steam\/sdk32\/steamclient.so\r\n\r\n## set up 64 bit libraries\r\nmkdir -p \/mnt\/server\/.steam\/sdk64\r\ncp -v linux64\/steamclient.so ..\/.steam\/sdk64\/steamclient.so\r\n\r\n## download the default server settings file\r\nmkdir -p \/mnt\/server\/AbioticFactor\/Saved\/SaveGames\/Server\/Worlds\/Cascade\r\ncurl -sS -o \/mnt\/server\/AbioticFactor\/Saved\/SaveGames\/Server\/Worlds\/Cascade\/SandboxSettings.ini https:\/\/raw.githubusercontent.com\/pelican-eggs\/steamcmd\/main\/abiotic_factor\/SandboxSettings.ini\r\n\r\n## install end\r\necho \"-----------------------------------------\"\r\necho \"Installation completed...\"\r\necho \"-----------------------------------------\"",
+            "container": "ghcr.io\/parkervcp\/installers:debian",
+            "entrypoint": "bash"
         }
     },
     "variables": [
@@ -37,7 +37,7 @@
             "default_value": "2857200",
             "user_viewable": false,
             "user_editable": false,
-            "rules": "required|numeric",
+            "rules": "required|numeric|in:2857200",
             "field_type": "text"
         },
         {


### PR DESCRIPTION
# Description

I just tried to use the current egg to setup Abiotic Factor and it was not working at all, after a lot of tests I found out the parameter in the egg is wrong for port, it should be `Port` and not `PORT`

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- If this is an egg update fill these out -->

* [x] You verify that the start command applied does not use a shell script
  * [x] If some script is needed then it is part of a current yolk or a PR to add one
* [x] The egg was exported from the panel