### PR TITLE
[Other] Fix broken author links

### DIFF
--- a/ark_survival_ascended/README.md
+++ b/ark_survival_ascended/README.md
@@ -13,21 +13,21 @@ ARK is reimagined from the ground-up into the next-generation of video game tech
                 <img src="https://avatars.githubusercontent.com/u/133905860" width="50px;" alt=""/><br /><sub><b>Blood Shot</b></sub>
             </a>
             <br />
-            <a href="https://github.com/parkervcp/eggs/commits?author=dagbs" title="Codes">💻</a>
-            <a href="https://github.com/parkervcp/eggs/commits?author=dagbs" title="Maintains">🔨</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=dagbs" title="Codes">💻</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=dagbs" title="Maintains">🔨</a>
         <td align="center">
             <a href="https://github.com/gOOvER">
                 <img src="https://avatars.githubusercontent.com/u/116325" width="50px;" alt=""/><br /><sub><b>gOOvER</b></sub>
             </a>
             <br />
-            <a href="https://github.com/parkervcp/eggs/commits?author=gOOvER" title="Codes">💻</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=gOOvER" title="Codes">💻</a>
         </td>
         <td align="center">
             <a href="https://github.com/hackles">
                 <img src="https://avatars.githubusercontent.com/u/30584261" width="50px;" alt=""/><br /><sub><b>heckler</b></sub>
             </a>
             <br />
-            <a href="https://github.com/parkervcp/eggs/commits?author=hackles" title="Codes">💻</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=hackles" title="Codes">💻</a>
         </td>
         </td>
         <td align="center">
@@ -35,28 +35,28 @@ ARK is reimagined from the ground-up into the next-generation of video game tech
                 <img src="https://avatars.githubusercontent.com/u/5745907" width="50px;" alt=""/><br /><sub><b>Brandon</b></sub>
             </a>
             <br />
-            <a href="https://github.com/parkervcp/eggs/commits?author=Log1x" title="Codes">💻</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=Log1x" title="Codes">💻</a>
         </td>  
         <td align="center">
             <a href="https://github.com/Ballaual">
                 <img src="https://avatars.githubusercontent.com/u/38478976" width="50px;" alt=""/><br /><sub><b>Alexander Ballauf</b></sub>
             </a>
             <br />
-            <a href="https://github.com/parkervcp/eggs/commits?author=Ballaual" title="Codes">💻</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=Ballaual" title="Codes">💻</a>
         </td> 
         <td align="center">
             <a href="https://github.com/MachinegunMarty">
                 <img src="https://avatars.githubusercontent.com/u/20025119" width="50px;" alt=""/><br /><sub><b>MachinegunMartyf</b></sub>
             </a>
             <br />
-            <a href="https://github.com/parkervcp/eggs/commits?author=MachinegunMarty" title="Contributor">💡</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=MachinegunMarty" title="Contributor">💡</a>
         </td>
         <td align="center">
             <a href="https://github.com/That411Guy">
                 <img src="https://avatars.githubusercontent.com/u/100328348" width="50px;" alt=""/><br /><sub><b>That411Guy</b></sub>
             </a>
             <br />
-            <a href="https://github.com/parkervcp/eggs/commits?author=That411Guy" title="Codes">💻</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=That411Guy" title="Codes">💻</a>
         </td>         
     </tr>
 </table>

--- a/arma/arma3/README.md
+++ b/arma/arma3/README.md
@@ -10,37 +10,37 @@ ___
 <table>
     <tr>
         <td align="center">
-            <a href="https://github.com/lilkingjr1">
+            <a href="https://github.com/redthirten">
                 <img src="https://avatars.githubusercontent.com/u/4533989" width="50px;" alt=""/><br /><sub><b>Red-Thirten</b></sub>
             </a>
             <br />
-            <a href="https://github.com/parkervcp/eggs/commits?author=lilkingjr1" title="Codes">💻</a>
-            <a href="https://github.com/parkervcp/eggs/commits?author=lilkingjr1" title="Maintains">🔨</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=redthirten" title="Codes">💻</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=redthirten" title="Maintains">🔨</a>
         </td>
         <td align="center">
             <a href="https://github.com/aussieserverhosts">
                 <img src="https://avatars.githubusercontent.com/u/65438932" width="50px;" alt=""/><br /><sub><b>Aussie Server Hosts</b></sub>
             </a>
             <br />
-            <a href="https://github.com/parkervcp/eggs/commits?author=aussieserverhosts" title="Codes">💻</a>
-            <a href="https://github.com/parkervcp/eggs/commits?author=aussieserverhosts" title="Contributor">💡</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=aussieserverhosts" title="Codes">💻</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=aussieserverhosts" title="Contributor">💡</a>
         </td>
         <td align="center">
             <a href="https://github.com/IAmSilK">
                 <img src="https://avatars.githubusercontent.com/u/16708907" width="50px;" alt=""/><br /><sub><b>IAmSilK</b></sub>
             </a>
             <br />
-            <a href="https://github.com/parkervcp/eggs/commits?author=IAmSilK" title="Codes">💻</a>
-            <a href="https://github.com/parkervcp/eggs/commits?author=IAmSilK" title="Contributor">💡</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=IAmSilK" title="Codes">💻</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=IAmSilK" title="Contributor">💡</a>
         </td>
         <td align="center">
             <a href="https://github.com/Yomanz">
                 <img src="https://avatars.githubusercontent.com/u/5119107" width="50px;" alt=""/><br /><sub><b>Daave</b></sub>
             </a>
             <br />
-            <a href="https://github.com/parkervcp/eggs/commits?author=Yomanz" title="Codes">💻</a>
-            <a href="https://github.com/parkervcp/eggs/commits?author=Yomanz" title="Original Creator">⭐</a>
-            <a href="https://github.com/parkervcp/eggs/commits?author=Yomanz" title="Retired from Development">💤</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=Yomanz" title="Codes">💻</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=Yomanz" title="Original Creator">⭐</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=Yomanz" title="Retired from Development">💤</a>
         </td>
     </tr>
 </table>

--- a/arma/arma_reforger/README.md
+++ b/arma/arma_reforger/README.md
@@ -10,19 +10,19 @@ ___
 <table>
     <tr>
         <td align="center">
-            <a href="https://github.com/lilkingjr1">
+            <a href="https://github.com/redthirten">
                 <img src="https://avatars.githubusercontent.com/u/4533989" width="50px;" alt=""/><br /><sub><b>Red-Thirten</b></sub>
             </a>
             <br />
-            <a href="https://github.com/parkervcp/eggs/commits?author=lilkingjr1" title="Codes">💻</a>
-            <a href="https://github.com/parkervcp/eggs/commits?author=lilkingjr1" title="Maintains">🔨</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=redthirten" title="Codes">💻</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=redthirten" title="Maintains">🔨</a>
         </td>
         <td align="center">
             <a href="https://github.com/Soljian">
                 <img src="https://avatars.githubusercontent.com/u/4036453" width="50px;" alt=""/><br /><sub><b>Soljian</b></sub>
             </a>
             <br />
-            <a href="https://github.com/parkervcp/eggs/commits?author=Soljian" title="Contributor">💡</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=Soljian" title="Contributor">💡</a>
         </td>
     </tr>
 </table>

--- a/dayz/README.md
+++ b/dayz/README.md
@@ -12,36 +12,36 @@ ___
 <table>
     <tr>
         <td align="center">
-            <a href="https://github.com/lilkingjr1">
+            <a href="https://github.com/redthirten">
                 <img src="https://avatars.githubusercontent.com/u/4533989" width="50px;" alt=""/><br /><sub><b>Red-Thirten</b></sub>
             </a>
             <br />
-            <a href="https://github.com/parkervcp/eggs/commits?author=lilkingjr1" title="Codes">💻</a>
-            <a href="https://github.com/parkervcp/eggs/commits?author=lilkingjr1" title="Maintains">🔨</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=redthirten" title="Codes">💻</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=redthirten" title="Maintains">🔨</a>
         </td>
         <td align="center">
             <a href="https://github.com/Moondarker">
                 <img src="https://avatars.githubusercontent.com/u/4098364" width="50px;" alt=""/><br /><sub><b>Moondarker</b></sub>
             </a>
             <br />
-            <a href="https://github.com/parkervcp/eggs/commits?author=Moondarker" title="Codes">💻</a>
-            <a href="https://github.com/parkervcp/eggs/commits?author=Moondarker" title="Contributor">💡</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=Moondarker" title="Codes">💻</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=Moondarker" title="Contributor">💡</a>
         </td>
         <td align="center">
             <a href="https://github.com/Brophy">
                 <img src="https://avatars.githubusercontent.com/u/123881" width="50px;" alt=""/><br /><sub><b>Brophy</b></sub>
             </a>
             <br />
-            <a href="https://github.com/parkervcp/eggs/commits?author=Brophy" title="Codes">💻</a>
-            <a href="https://github.com/parkervcp/eggs/commits?author=Brophy" title="Contributor">💡</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=Brophy" title="Codes">💻</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=Brophy" title="Contributor">💡</a>
         </td>
         <td align="center">
             <a href="https://github.com/shaynendradika">
                 <img src="https://avatars.githubusercontent.com/u/19285167" width="50px;" alt=""/><br /><sub><b>shaynendradika</b></sub>
             </a>
             <br />
-            <a href="https://github.com/parkervcp/eggs/commits?author=shaynendradika" title="Codes">💻</a>
-            <a href="https://github.com/parkervcp/eggs/commits?author=shaynendradika" title="Contributor">💡</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=shaynendradika" title="Codes">💻</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=shaynendradika" title="Contributor">💡</a>
         </td>
     </tr>
 </table>

--- a/ground_branch/README.md
+++ b/ground_branch/README.md
@@ -10,13 +10,13 @@ ___
 <table>
     <tr>
         <td align="center">
-            <a href="https://github.com/lilkingjr1">
+            <a href="https://github.com/redthirten">
                 <img src="https://avatars.githubusercontent.com/u/4533989" width="50px;" alt=""/><br /><sub><b>Red-Thirten</b></sub>
             </a>
             <br />
-            <a href="https://github.com/parkervcp/eggs/commits?author=lilkingjr1" title="Original Author">⭐</a>
-            <a href="https://github.com/parkervcp/eggs/commits?author=lilkingjr1" title="Codes">💻</a>
-            <a href="https://github.com/parkervcp/eggs/commits?author=lilkingjr1" title="Maintains">🔨</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=redthirten" title="Original Author">⭐</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=redthirten" title="Codes">💻</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=redthirten" title="Maintains">🔨</a>
         </td>
     </tr>
 </table>

--- a/palworld/README.md
+++ b/palworld/README.md
@@ -11,21 +11,21 @@ Fight, farm, build and work alongside mysterious creatures called "Pals" in this
                 <img src="https://avatars.githubusercontent.com/u/38478976" width="50px;" alt=""/><br /><sub><b>Alexander Ballauf</b></sub>
             </a>
             <br />
-            <a href="https://github.com/parkervcp/eggs/issues/2669#issuecomment-1900216079" title="Codes">💻</a>
-            <a href="https://github.com/parkervcp/eggs/commits?author=Ballaual" title="Maintains">🔨</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/issues/2669#issuecomment-1900216079" title="Codes">💻</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=Ballaual" title="Maintains">🔨</a>
         </td>
         <td align="center">
             <a href="https://github.com/QuintenQVD0">
                 <img src="https://avatars.githubusercontent.com/u/67589015" width="50px;" alt=""/><br /><sub><b>QuintenQVD0</b></sub>
             </a>
             <br />
-            <a href="https://github.com/parkervcp/eggs/issues/2669#issuecomment-1899999796" title="Codes">💻</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/issues/2669#issuecomment-1899999796" title="Codes">💻</a>
         <td align="center">
             <a href="https://github.com/hackles">
                 <img src="https://avatars.githubusercontent.com/u/30584261" width="50px;" alt=""/><br /><sub><b>heckler</b></sub>
             </a>
             <br />
-            <a href="https://github.com/parkervcp/eggs/issues/2669#issuecomment-1900043987" title="Contributor">💡</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/issues/2669#issuecomment-1900043987" title="Contributor">💡</a>
         </td>
         </td>
         <td align="center">
@@ -33,28 +33,28 @@ Fight, farm, build and work alongside mysterious creatures called "Pals" in this
                 <img src="https://avatars.githubusercontent.com/u/388231" width="50px;" alt=""/><br /><sub><b>Daniel Barton</b></sub>
             </a>
             <br />
-            <a href="https://github.com/parkervcp/eggs/issues/2669#issuecomment-1900100992" title="Codes">💻</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/issues/2669#issuecomment-1900100992" title="Codes">💻</a>
         </td>  
         <td align="center">
             <a href="https://github.com/Rodhin">
                 <img src="https://avatars.githubusercontent.com/u/13395074" width="50px;" alt=""/><br /><sub><b>Rodhin</b></sub>
             </a>
             <br />
-            <a href="https://github.com/parkervcp/eggs/issues/2669#issuecomment-1900153550" title="Codes">💻</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/issues/2669#issuecomment-1900153550" title="Codes">💻</a>
         </td> 
         <td align="center">
             <a href="https://github.com/B0rbor4d">
                 <img src="https://avatars.githubusercontent.com/u/33213807" width="50px;" alt=""/><br /><sub><b>B0rbor4d</b></sub>
             </a>
             <br />
-            <a href="https://github.com/parkervcp/eggs/issues/2669#issuecomment-1900213758" title="Contributor">💡</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/issues/2669#issuecomment-1900213758" title="Contributor">💡</a>
         </td>
         <td align="center">
             <a href="https://github.com/Simsz">
                 <img src="https://avatars.githubusercontent.com/u/12779829" width="50px;" alt=""/><br /><sub><b>Zach</b></sub>
             </a>
             <br />
-            <a href="https://github.com/parkervcp/eggs/issues/2669#issuecomment-1899954711" title="Contributor">💡</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/issues/2669#issuecomment-1899954711" title="Contributor">💡</a>
         </td>         
     </tr>
 </table>

--- a/satisfactory/README.md
+++ b/satisfactory/README.md
@@ -14,59 +14,59 @@ ___
 <table>
     <tr>
         <td align="center">
-            <a href="https://github.com/lilkingjr1">
+            <a href="https://github.com/redthirten">
                 <img src="https://avatars.githubusercontent.com/u/4533989" width="50px;" alt=""/><br /><sub><b>Red-Thirten</b></sub>
             </a>
             <br />
-            <a href="https://github.com/parkervcp/eggs/commits?author=lilkingjr1" title="Codes">💻</a>
-            <a href="https://github.com/parkervcp/eggs/commits?author=lilkingjr1" title="Maintains">🔨</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=redthirten" title="Codes">💻</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=redthirten" title="Maintains">🔨</a>
         </td>
         <td align="center">
             <a href="https://github.com/iamkubi">
                 <img src="https://avatars.githubusercontent.com/u/6176191" width="50px;" alt=""/><br /><sub><b>Kubi</b></sub>
             </a>
             <br />
-            <a href="https://github.com/parkervcp/eggs/commits?author=iamkubi" title="Codes">💻</a>
-            <a href="https://github.com/parkervcp/eggs/commits?author=iamkubi" title="Contributor">💡</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=iamkubi" title="Codes">💻</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=iamkubi" title="Contributor">💡</a>
         </td>
         <td align="center">
             <a href="https://github.com/matthewpi">
                 <img src="https://avatars.githubusercontent.com/u/26559841" width="50px;" alt=""/><br /><sub><b>matthewpi</b></sub>
             </a>
             <br />
-            <a href="https://github.com/parkervcp/eggs/commits?author=matthewpi" title="Codes">💻</a>
-            <a href="https://github.com/parkervcp/eggs/commits?author=matthewpi" title="Contributor">💡</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=matthewpi" title="Codes">💻</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=matthewpi" title="Contributor">💡</a>
         </td>
         <td align="center">
             <a href="https://github.com/Software-Noob">
                 <img src="https://avatars.githubusercontent.com/u/10975908" width="50px;" alt=""/><br /><sub><b>Software-Noob</b></sub>
             </a>
             <br />
-            <a href="https://github.com/parkervcp/eggs/commits?author=Software-Noob" title="Codes">💻</a>
-            <a href="https://github.com/parkervcp/eggs/commits?author=Software-Noob" title="Contributor">💡</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=Software-Noob" title="Codes">💻</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=Software-Noob" title="Contributor">💡</a>
         </td>
         <td align="center">
             <a href="https://github.com/Zarklord">
                 <img src="https://avatars.githubusercontent.com/u/1622280" width="50px;" alt=""/><br /><sub><b>Zarklord</b></sub>
             </a>
             <br />
-            <a href="https://github.com/parkervcp/eggs/commits?author=Zarklord" title="Codes">💻</a>
-            <a href="https://github.com/parkervcp/eggs/commits?author=Zarklord" title="Contributor">💡</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=Zarklord" title="Codes">💻</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=Zarklord" title="Contributor">💡</a>
         </td>
         <td align="center">
             <a href="https://github.com/AlienXAXS">
                 <img src="https://avatars.githubusercontent.com/u/1773445" width="50px;" alt=""/><br /><sub><b>AlienXAXS</b></sub>
             </a>
             <br />
-            <a href="https://github.com/parkervcp/eggs/commits?author=AlienXAXS" title="Contributor">💡</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=AlienXAXS" title="Contributor">💡</a>
         </td>
         <td align="center">
             <a href="https://github.com/gOOvER">
                 <img src="https://avatars.githubusercontent.com/u/116325?v=4" width="50px;" alt=""/><br /><sub><b>gOOvER</b></sub>
             </a>
             <br />
-            <a href="https://github.com/parkervcp/eggs/commits?author=gOOvER" title="Codes">💻</a>
-            <a href="https://github.com/parkervcp/eggs/commits?author=gOOvER" title="Contributor">💡</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=gOOvER" title="Codes">💻</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=gOOvER" title="Contributor">💡</a>
         </td>
     </tr>
 </table>

--- a/sourcecoop/README.md
+++ b/sourcecoop/README.md
@@ -7,12 +7,12 @@
 <table>
     <tr>
         <td align="center">
-            <a href="https://github.com/lilkingjr1">
+            <a href="https://github.com/redthirten">
                 <img src="https://avatars.githubusercontent.com/u/4533989" width="50px;" alt=""/><br /><sub><b>Red-Thirten</b></sub>
             </a>
             <br />
-            <a href="https://github.com/parkervcp/eggs/commits?author=lilkingjr1" title="Codes">💻</a>
-            <a href="https://github.com/parkervcp/eggs/commits?author=lilkingjr1" title="Maintains">🔨</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=redthirten" title="Codes">💻</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=redthirten" title="Maintains">🔨</a>
         </td>
     </tr>
 </table>

--- a/v_rising/v_rising_bepinex/README.md
+++ b/v_rising/v_rising_bepinex/README.md
@@ -12,36 +12,36 @@
 <table>
     <tr>
         <td align="center">
-            <a href="https://github.com/lilkingjr1">
+            <a href="https://github.com/redthirten">
                 <img src="https://avatars.githubusercontent.com/u/4533989" width="50px;" alt=""/><br /><sub><b>Red-Thirten</b></sub>
             </a>
             <br />
-            <a href="https://github.com/parkervcp/eggs/commits?author=lilkingjr1" title="Codes">💻</a>
-            <a href="https://github.com/parkervcp/eggs/commits?author=lilkingjr1" title="Contributor">💡</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=redthirten" title="Codes">💻</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=redthirten" title="Contributor">💡</a>
         </td>
         <td align="center">
             <a href="https://github.com/kapatheus">
                 <img src="https://avatars.githubusercontent.com/u/59861026" width="50px;" alt=""/><br /><sub><b>Kapatheus</b></sub>
             </a>
             <br />
-            <a href="https://github.com/parkervcp/eggs/commits?author=kapatheus" title="Codes">💻</a>
-            <a href="https://github.com/parkervcp/eggs/commits?author=kapatheus" title="Contributor">💡</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=kapatheus" title="Codes">💻</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=kapatheus" title="Contributor">💡</a>
         </td>
         <td align="center">
             <a href="https://github.com/upd4ting">
                 <img src="https://avatars.githubusercontent.com/u/6763934" width="50px;" alt=""/><br /><sub><b>Upd4ting</b></sub>
             </a>
             <br />
-            <a href="https://github.com/parkervcp/eggs/commits?author=upd4ting" title="Codes">💻</a>
-            <a href="https://github.com/parkervcp/eggs/commits?author=upd4ting" title="Maintains">🔨</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=upd4ting" title="Codes">💻</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=upd4ting" title="Maintains">🔨</a>
         </td>
         <td align="center">
             <a href="https://github.com/gOOvER">
                 <img src="https://avatars.githubusercontent.com/u/116325" width="50px;" alt=""/><br /><sub><b>gOOvER</b></sub>
             </a>
             <br />
-            <a href="https://github.com/parkervcp/eggs/commits?author=gOOvER" title="Codes">💻</a>
-            <a href="https://github.com/parkervcp/eggs/commits?author=gOOvER" title="Maintains">🔨</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=gOOvER" title="Codes">💻</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=gOOvER" title="Maintains">🔨</a>
         </td>
     </tr>
 </table>

--- a/v_rising/v_rising_vanilla/README.md
+++ b/v_rising/v_rising_vanilla/README.md
@@ -7,20 +7,20 @@
 <table>
     <tr>
         <td align="center">
-            <a href="https://github.com/lilkingjr1">
+            <a href="https://github.com/redthirten">
                 <img src="https://avatars.githubusercontent.com/u/4533989" width="50px;" alt=""/><br /><sub><b>Red-Thirten</b></sub>
             </a>
             <br />
-            <a href="https://github.com/parkervcp/eggs/commits?author=lilkingjr1" title="Codes">💻</a>
-            <a href="https://github.com/parkervcp/eggs/commits?author=lilkingjr1" title="Maintains">🔨</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=redthirten" title="Codes">💻</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=redthirten" title="Maintains">🔨</a>
         </td>
         <td align="center">
             <a href="https://github.com/kapatheus">
                 <img src="https://avatars.githubusercontent.com/u/59861026" width="50px;" alt=""/><br /><sub><b>Kapatheus</b></sub>
             </a>
             <br />
-            <a href="https://github.com/parkervcp/eggs/commits?author=kapatheus" title="Codes">💻</a>
-            <a href="https://github.com/parkervcp/eggs/commits?author=kapatheus" title="Contributor">💡</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=kapatheus" title="Codes">💻</a>
+            <a href="https://github.com/pelican-eggs/games-steamcmd/commits?author=kapatheus" title="Contributor">💡</a>
         </td>
     </tr>
 </table>


### PR DESCRIPTION
# Description

I changed my Github username a while back and assumed the links would auto-forward, but unfortunately they do not. This PR corrects all of my author Github links across the repository. This also corrects any `parkervcp/eggs` links with `pelican-eggs/games-steamcmd`.

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?