### PR TITLE
Add Brickadia Pelican Egg

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 * [Barotrauma](barotrauma)
 * [BATTALION: Legacy](/battalion_legacy)
 * [Black Mesa](black_mesa)
+* [Brickadia](brickadia)
 * [Citadel: Forged with Fire](citadel)
 * [Colony Survival](colony_survival)
 * [Conan Exiles](conan_exiles)

--- a/brickadia/egg-brickadia.json
+++ b/brickadia/egg-brickadia.json
@@ -1,0 +1,100 @@
+{
+    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
+    "meta": {
+        "version": "PLCN_v1",
+        "update_url": null
+    },
+    "exported_at": "2025-07-25T18:11:42+00:00",
+    "name": "Brickadia",
+    "author": "felinusfish@gmail.com",
+    "uuid": "3ee993b6-124a-4260-85fe-b622ebddded7",
+    "description": "Brickadia is a new multiplayer brick building sandbox game that gives you all the tools to create and play, your way. Build and invent with your friends, drive a car through space, create your own interactive experiences, or blow it all to smithereens!",
+    "tags": [],
+    "features": [],
+    "docker_images": {
+        "Debian": "ghcr.io\/parkervcp\/steamcmd:debian",
+        "Mono": "ghcr.io\/parkervcp\/yolks:mono_latest"
+    },
+    "file_denylist": [],
+    "startup": ".\/Brickadia\/Binaries\/Linux\/BrickadiaServer-Linux-Shipping -- -token={{BRICKADIA_TOKEN}} -- -port={{server.allocations.default.port}}",
+    "config": {
+        "files": "{}",
+        "startup": "{\n    \"done\": \"Posting server.\"\n}",
+        "logs": "{}",
+        "stop": "quit"
+    },
+    "scripts": {
+        "installation": {
+            "script": "#!\/bin\/bash\r\n# steamcmd Base Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\n# Image to install with is 'ghcr.io\/parkervcp\/installers:debian'\r\n\r\n##\r\n#\r\n# Variables\r\n# STEAM_USER, STEAM_PASS, STEAM_AUTH - Steam user setup. If a user has 2fa enabled it will most likely fail due to timeout. Leave blank for anon install.\r\n# WINDOWS_INSTALL - if it's a windows server you want to install set to 1\r\n# SRCDS_APPID - steam app id found here - https:\/\/developer.valvesoftware.com\/wiki\/Dedicated_Servers_List\r\n# SRCDS_BETAID - beta branch of a steam app. Leave blank to install normal branch\r\n# SRCDS_BETAPASS - password for a beta branch should one be required during private or closed testing phases.. Leave blank for no password.\r\n# INSTALL_FLAGS - Any additional SteamCMD  flags to pass during install.. Keep in mind that steamcmd auto update process in the docker image might overwrite or ignore these when it performs update on server boot.\r\n# AUTO_UPDATE - Adding this variable to the egg allows disabling or enabling automated updates on boot. Boolean value. 0 to disable and 1 to enable.\r\n#\r\n ##\r\n\r\n# Install packages. Default packages below are not required if using our existing install image thus speeding up the install process.\r\n#apt -y update\r\n#apt -y --no-install-recommends install curl lib32gcc-s1 ca-certificates\r\n\r\n## just in case someone removed the defaults.\r\nif [[ \"${STEAM_USER}\" == \"\" ]] || [[ \"${STEAM_PASS}\" == \"\" ]]; then\r\n    echo -e \"steam user is not set.\\n\"\r\n    echo -e \"Using anonymous user.\\n\"\r\n    STEAM_USER=anonymous\r\n    STEAM_PASS=\"\"\r\n    STEAM_AUTH=\"\"\r\nelse\r\n    echo -e \"user set to ${STEAM_USER}\"\r\nfi\r\n\r\n## download and install steamcmd\r\ncd \/tmp\r\nmkdir -p \/mnt\/server\/steamcmd\r\ncurl -sSL -o steamcmd.tar.gz https:\/\/steamcdn-a.akamaihd.net\/client\/installer\/steamcmd_linux.tar.gz\r\ntar -xzvf steamcmd.tar.gz -C \/mnt\/server\/steamcmd\r\nmkdir -p \/mnt\/server\/steamapps # Fix steamcmd disk write error when this folder is missing\r\ncd \/mnt\/server\/steamcmd\r\n\r\n# SteamCMD fails otherwise for some reason, even running as root.\r\n# This is changed at the end of the install process anyways.\r\nchown -R root:root \/mnt\r\nexport HOME=\/mnt\/server\r\n\r\n## install game using steamcmd\r\n.\/steamcmd.sh +force_install_dir \/mnt\/server +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} $( [[ \"${WINDOWS_INSTALL}\" == \"1\" ]] && printf %s '+@sSteamCmdForcePlatformType windows' ) +app_update ${SRCDS_APPID} $( [[ -z ${SRCDS_BETAID} ]] || printf %s \"-beta ${SRCDS_BETAID}\" ) $( [[ -z ${SRCDS_BETAPASS} ]] || printf %s \"-betapassword ${SRCDS_BETAPASS}\" ) ${INSTALL_FLAGS} validate +quit ## other flags may be needed depending on install. looking at you cs 1.6\r\n\r\n## set up 32 bit libraries\r\nmkdir -p \/mnt\/server\/.steam\/sdk32\r\ncp -v linux32\/steamclient.so ..\/.steam\/sdk32\/steamclient.so\r\n\r\n## set up 64 bit libraries\r\nmkdir -p \/mnt\/server\/.steam\/sdk64\r\ncp -v linux64\/steamclient.so ..\/.steam\/sdk64\/steamclient.so\r\n\r\n## add below your custom commands if needed\r\n\r\n## install end\r\necho \"-----------------------------------------\"\r\necho \"Installation completed...\"\r\necho \"-----------------------------------------\"",
+            "container": "ghcr.io\/pelican-eggs\/installers:debian",
+            "entrypoint": "bash"
+        }
+    },
+    "variables": [
+        {
+            "name": "Brickadia Dedicated Server Token",
+            "description": "This is the token generated on the Brickadia website. You won't be able to host without one.",
+            "env_variable": "BRICKADIA_TOKEN",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "required"
+            ],
+            "sort": 2
+        },
+        {
+            "name": "Steam App ID",
+            "description": "",
+            "env_variable": "SRCDS_APPID",
+            "default_value": "3017590",
+            "user_viewable": true,
+            "user_editable": false,
+            "rules": [],
+            "sort": 1
+        },
+        {
+            "name": "Steam Auth",
+            "description": "Steam will likely time out before ever reaching this point.",
+            "env_variable": "STEAM_AUTH",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [],
+            "sort": 6
+        },
+        {
+            "name": "Steam Auto-Updates",
+            "description": "Disable or enable the auto-updates. By default, it's recommended that you leave this on, otherwise you may not be able to join your server if it is outdated.",
+            "env_variable": "AUTO_UPDATE",
+            "default_value": "1",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "required",
+                "boolean"
+            ],
+            "sort": 5
+        },
+        {
+            "name": "Steam Password",
+            "description": "Leave blank if you want to remain anonymous.",
+            "env_variable": "STEAM_PASS",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [],
+            "sort": 4
+        },
+        {
+            "name": "Steam Username",
+            "description": "Leave blank if you want to remain anonymous.",
+            "env_variable": "STEAM_USER",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [],
+            "sort": 3
+        }
+    ]
+}


### PR DESCRIPTION
# Description

This PR adds Brickadia as an Egg for Pelican. It has all of the necessary variables for being able to host a game server. I've asked the developers on if there are any additional start-up arguments, and as of right now, these are the only available arguments.

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/pelican-eggs/games-steamcmd/blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
  * _(There is an existing PR, but is related to Pterodactyl, and is also not as configurable out of the box.)_
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- You can erase the new egg submission template if you're not adding a completely new egg -->

## New egg Submissions

1. [x] Does your submission pass tests (server is connectable)?
2. [ ] Does your egg use a custom docker image?
    * [ ] Have you tried to use a generic image?
    * [ ] Did you PR the necessary changes to make it work?
3. [x] Have you added the egg to the main README.md and any other README files in subdirectories of the egg (e.g /game_eggs) according to the alphabetical order?
4. [ ] Have you added a unique README.md for the egg you are adding according to the alphabetical order?
5. [x] You verify that the start command applied does not use a shell script
    * [ ] If some script is needed then it is part of a current yolk or a PR to add one
6. [x] The egg was exported from the panel