### PR TITLE
Use Valve's cs2.sh script to start the server as stated in the official wiki

### DIFF
--- a/counter_strike/counter_strike_2/egg-counter--strike2.json
+++ b/counter_strike/counter_strike_2/egg-counter--strike2.json
@@ -1,14 +1,15 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
-        "version": "PTDL_v2",
+        "version": "PLCN_v1",
         "update_url": null
     },
-    "exported_at": "2024-06-01T00:04:01+00:00",
+    "exported_at": "2025-10-04T16:04:33+00:00",
     "name": "Counter-Strike 2",
     "author": "admin@ballaual.de",
     "uuid": "d2991753-0db4-4b68-9f5d-11f997019b78",
     "description": "For over two decades, Counter-Strike has offered an elite competitive experience, one shaped by millions of players from across the globe. And now the next chapter in the CS story is about to begin. This is Counter-Strike 2.",
+    "tags": [],
     "features": [
         "steam_disk_space"
     ],
@@ -16,7 +17,7 @@
         "ghcr.io\/parkervcp\/steamcmd:sniper": "ghcr.io\/parkervcp\/steamcmd:sniper"
     },
     "file_denylist": [],
-    "startup": ".\/game\/bin\/linuxsteamrt64\/cs2 -dedicated $( [ \"$VAC_ENABLED\" == \"1\" ] || printf %s ' -insecure' ) -ip 0.0.0.0 -port {{SERVER_PORT}} -tv_port {{TV_PORT}} -maxplayers {{MAX_PLAYERS}} $( [ \"$RCON_ENABLED\" == \"0\" ] || printf %s ' -usercon' ) +game_mode {{GAME_MODE}} +game_type {{GAME_TYPE}} +map {{SRCDS_MAP}} +hostname \"{{SERVER_NAME}}\" +sv_password \"{{SERVER_PASSWORD}}\" +rcon_password \"{{RCON_PASSWORD}}\" +sv_setsteamaccount {{STEAM_GSLT}}",
+    "startup": ".\/game\/cs2.sh -dedicated $( [ \"$VAC_ENABLED\" == \"1\" ] || printf %s ' -insecure' ) -ip 0.0.0.0 -port {{SERVER_PORT}} -tv_port {{TV_PORT}} -maxplayers {{MAX_PLAYERS}} $( [ \"$RCON_ENABLED\" == \"0\" ] || printf %s ' -usercon' ) +game_mode {{GAME_MODE}} +game_type {{GAME_TYPE}} +map {{SRCDS_MAP}} +hostname \"{{SERVER_NAME}}\" +sv_password \"{{SERVER_PASSWORD}}\" +rcon_password \"{{RCON_PASSWORD}}\" +sv_setsteamaccount {{STEAM_GSLT}}",
     "config": {
         "files": "{}",
         "startup": "{\r\n    \"done\": \"Connection to Steam servers successful\"\r\n}",
@@ -32,81 +33,17 @@
     },
     "variables": [
         {
-            "name": "Map",
-            "description": "The default map for the server.\r\nExamples:\r\n\r\nBomb:\r\nde_dust2, de_mirage, de_nuke, de_overpass, de_inferno, de_ancient, de_vertigo, de_anubis\r\n\r\nHostage:\r\ncs_italy, cs_office\r\n\r\nArms Race:\r\nar_baggage, ar_shoots",
-            "env_variable": "SRCDS_MAP",
-            "default_value": "de_dust2",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": "required|string",
-            "sort": null,
-            "field_type": "text"
-        },
-        {
-            "name": "Source AppID",
-            "description": "Required for game to update on server restart. Do not modify this.",
-            "env_variable": "SRCDS_APPID",
-            "default_value": "730",
-            "user_viewable": false,
-            "user_editable": false,
-            "rules": "required|string|in:730",
-            "sort": null,
-            "field_type": "text"
-        },
-        {
-            "name": "Max Players",
-            "description": "Specifies the maximum amount of players that are able to join the server.",
-            "env_variable": "MAX_PLAYERS",
-            "default_value": "12",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": "required|numeric|between:1,64",
-            "sort": null,
-            "field_type": "text"
-        },
-        {
             "name": "Auto-update server",
             "description": "This is to enable \/ disable auto-updating your server on restart.\r\n\r\nBy default this is set to enabled.",
             "env_variable": "AUTO_UPDATE",
             "default_value": "1",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|boolean",
-            "sort": null,
-            "field_type": "text"
-        },
-        {
-            "name": "SourceTV Port",
-            "description": "SourceTV port used for connections to spectates games on your server.",
-            "env_variable": "TV_PORT",
-            "default_value": "27020",
-            "user_viewable": true,
-            "user_editable": false,
-            "rules": "required|integer|between:1025,65535",
-            "sort": null,
-            "field_type": "text"
-        },
-        {
-            "name": "Steam Gameserver Login Token",
-            "description": "The Steam Account Token required for the server to be displayed public. The token can be acquired here: https:\/\/steamcommunity.com\/dev\/managegameservers",
-            "env_variable": "STEAM_GSLT",
-            "default_value": "",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": "required|string|alpha_num|size:32",
-            "sort": null,
-            "field_type": "text"
-        },
-        {
-            "name": "Enable VAC",
-            "description": "Enable \/ Disable VAC (Valve Anti Cheat) on your server. By default this will be enabled.",
-            "env_variable": "VAC_ENABLED",
-            "default_value": "1",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": "required|boolean",
-            "sort": null,
-            "field_type": "text"
+            "rules": [
+                "required",
+                "boolean"
+            ],
+            "sort": 1
         },
         {
             "name": "Enable RCON",
@@ -115,42 +52,24 @@
             "default_value": "0",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|boolean",
-            "sort": null,
-            "field_type": "text"
+            "rules": [
+                "required",
+                "boolean"
+            ],
+            "sort": 2
         },
         {
-            "name": "Server Name",
-            "description": "Sets the server name listed in the steam server browser.",
-            "env_variable": "SERVER_NAME",
-            "default_value": "A Pterodactyl hosted CS2 Server",
+            "name": "Enable VAC",
+            "description": "Enable \/ Disable VAC (Valve Anti Cheat) on your server. By default this will be enabled.",
+            "env_variable": "VAC_ENABLED",
+            "default_value": "1",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string|max:64",
-            "sort": null,
-            "field_type": "text"
-        },
-        {
-            "name": "Server Password",
-            "description": "If specified, players must provide this password to join the server.",
-            "env_variable": "SERVER_PASSWORD",
-            "default_value": "",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": "nullable|alpha_dash|between:1,30",
-            "sort": null,
-            "field_type": "text"
-        },
-        {
-            "name": "RCON Password",
-            "description": "To gain access to administrator commands on the server.",
-            "env_variable": "RCON_PASSWORD",
-            "default_value": "",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": "required|alpha_dash|between:1,30",
-            "sort": null,
-            "field_type": "text"
+            "rules": [
+                "required",
+                "boolean"
+            ],
+            "sort": 3
         },
         {
             "name": "Gamemode",
@@ -159,9 +78,11 @@
             "default_value": "1",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string",
-            "sort": null,
-            "field_type": "text"
+            "rules": [
+                "required",
+                "string"
+            ],
+            "sort": 4
         },
         {
             "name": "Gametype",
@@ -170,9 +91,123 @@
             "default_value": "0",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string",
-            "sort": null,
-            "field_type": "text"
+            "rules": [
+                "required",
+                "string"
+            ],
+            "sort": 5
+        },
+        {
+            "name": "Map",
+            "description": "The default map for the server.\r\nExamples:\r\n\r\nBomb:\r\nde_dust2, de_mirage, de_nuke, de_overpass, de_inferno, de_ancient, de_vertigo, de_anubis\r\n\r\nHostage:\r\ncs_italy, cs_office\r\n\r\nArms Race:\r\nar_baggage, ar_shoots",
+            "env_variable": "SRCDS_MAP",
+            "default_value": "de_dust2",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "required",
+                "string"
+            ],
+            "sort": 6
+        },
+        {
+            "name": "Max Players",
+            "description": "Specifies the maximum amount of players that are able to join the server.",
+            "env_variable": "MAX_PLAYERS",
+            "default_value": "12",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "required",
+                "numeric",
+                "between:1,64"
+            ],
+            "sort": 7
+        },
+        {
+            "name": "RCON Password",
+            "description": "To gain access to administrator commands on the server.",
+            "env_variable": "RCON_PASSWORD",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "required",
+                "alpha_dash",
+                "between:1,30"
+            ],
+            "sort": 8
+        },
+        {
+            "name": "Server Name",
+            "description": "Sets the server name listed in the steam server browser.",
+            "env_variable": "SERVER_NAME",
+            "default_value": "A Pterodactyl hosted CS2 Server",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "required",
+                "string",
+                "max:64"
+            ],
+            "sort": 9
+        },
+        {
+            "name": "Server Password",
+            "description": "If specified, players must provide this password to join the server.",
+            "env_variable": "SERVER_PASSWORD",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "nullable",
+                "alpha_dash",
+                "between:1,30"
+            ],
+            "sort": 10
+        },
+        {
+            "name": "Source AppID",
+            "description": "Required for game to update on server restart. Do not modify this.",
+            "env_variable": "SRCDS_APPID",
+            "default_value": "730",
+            "user_viewable": false,
+            "user_editable": false,
+            "rules": [
+                "required",
+                "string",
+                "in:730"
+            ],
+            "sort": 11
+        },
+        {
+            "name": "SourceTV Port",
+            "description": "SourceTV port used for connections to spectates games on your server.",
+            "env_variable": "TV_PORT",
+            "default_value": "27020",
+            "user_viewable": true,
+            "user_editable": false,
+            "rules": [
+                "required",
+                "integer",
+                "between:1025,65535"
+            ],
+            "sort": 12
+        },
+        {
+            "name": "Steam Gameserver Login Token",
+            "description": "The Steam Account Token required for the server to be displayed public. The token can be acquired here: https:\/\/steamcommunity.com\/dev\/managegameservers",
+            "env_variable": "STEAM_GSLT",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "required",
+                "string",
+                "alpha_num",
+                "size:32"
+            ],
+            "sort": 13
         }
     ]
 }

--- a/counter_strike/counter_strike_2/egg-counter--strike2.json
+++ b/counter_strike/counter_strike_2/egg-counter--strike2.json
@@ -16,7 +16,7 @@
         "ghcr.io\/parkervcp\/steamcmd:sniper": "ghcr.io\/parkervcp\/steamcmd:sniper"
     },
     "file_denylist": [],
-    "startup": ".\/game\/bin\/linuxsteamrt64\/cs2 -dedicated $( [ \"$VAC_ENABLED\" == \"1\" ] || printf %s ' -insecure' ) -ip 0.0.0.0 -port {{SERVER_PORT}} -tv_port {{TV_PORT}} -maxplayers {{MAX_PLAYERS}} $( [ \"$RCON_ENABLED\" == \"0\" ] || printf %s ' -usercon' ) +game_mode {{GAME_MODE}} +game_type {{GAME_TYPE}} +map {{SRCDS_MAP}} +hostname \"{{SERVER_NAME}}\" +sv_password \"{{SERVER_PASSWORD}}\" +rcon_password \"{{RCON_PASSWORD}}\" +sv_setsteamaccount {{STEAM_GSLT}}",
+    "startup": ".\/game\/cs2.sh -dedicated $( [ \"$VAC_ENABLED\" == \"1\" ] || printf %s ' -insecure' ) -ip 0.0.0.0 -port {{SERVER_PORT}} -tv_port {{TV_PORT}} -maxplayers {{MAX_PLAYERS}} $( [ \"$RCON_ENABLED\" == \"0\" ] || printf %s ' -usercon' ) +game_mode {{GAME_MODE}} +game_type {{GAME_TYPE}} +map {{SRCDS_MAP}} +hostname \"{{SERVER_NAME}}\" +sv_password \"{{SERVER_PASSWORD}}\" +rcon_password \"{{RCON_PASSWORD}}\" +sv_setsteamaccount {{STEAM_GSLT}}",
     "config": {
         "files": "{}",
         "startup": "{\r\n    \"done\": \"Connection to Steam servers successful\"\r\n}",

--- a/counter_strike/counter_strike_2/egg-counter--strike2.json
+++ b/counter_strike/counter_strike_2/egg-counter--strike2.json
@@ -1,14 +1,15 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
-        "version": "PTDL_v2",
+        "version": "PLCN_v1",
         "update_url": null
     },
-    "exported_at": "2024-06-01T00:04:01+00:00",
+    "exported_at": "2025-10-06T00:18:42+00:00",
     "name": "Counter-Strike 2",
     "author": "admin@ballaual.de",
     "uuid": "d2991753-0db4-4b68-9f5d-11f997019b78",
     "description": "For over two decades, Counter-Strike has offered an elite competitive experience, one shaped by millions of players from across the globe. And now the next chapter in the CS story is about to begin. This is Counter-Strike 2.",
+    "tags": [],
     "features": [
         "steam_disk_space"
     ],
@@ -16,7 +17,7 @@
         "ghcr.io\/parkervcp\/steamcmd:sniper": "ghcr.io\/parkervcp\/steamcmd:sniper"
     },
     "file_denylist": [],
-    "startup": ".\/game\/bin\/linuxsteamrt64\/cs2 -dedicated $( [ \"$VAC_ENABLED\" == \"1\" ] || printf %s ' -insecure' ) -ip 0.0.0.0 -port {{SERVER_PORT}} -tv_port {{TV_PORT}} -maxplayers {{MAX_PLAYERS}} $( [ \"$RCON_ENABLED\" == \"0\" ] || printf %s ' -usercon' ) +game_mode {{GAME_MODE}} +game_type {{GAME_TYPE}} +map {{SRCDS_MAP}} +hostname \"{{SERVER_NAME}}\" +sv_password \"{{SERVER_PASSWORD}}\" +rcon_password \"{{RCON_PASSWORD}}\" +sv_setsteamaccount {{STEAM_GSLT}}",
+    "startup": "LD_LIBRARY_PATH=$HOME\/game\/bin\/linuxsteamrt64:$LD_LIBRARY_PATH .\/game\/bin\/linuxsteamrt64\/cs2 -dedicated $( [ \"$VAC_ENABLED\" == \"1\" ] || printf %s ' -insecure' ) -ip 0.0.0.0 -port {{SERVER_PORT}} -tv_port {{TV_PORT}} -maxplayers {{MAX_PLAYERS}} $( [ \"$RCON_ENABLED\" == \"0\" ] || printf %s ' -usercon' ) +game_mode {{GAME_MODE}} +game_type {{GAME_TYPE}} +map {{SRCDS_MAP}} +hostname \"{{SERVER_NAME}}\" +sv_password \"{{SERVER_PASSWORD}}\" +rcon_password \"{{RCON_PASSWORD}}\" +sv_setsteamaccount {{STEAM_GSLT}}",
     "config": {
         "files": "{}",
         "startup": "{\r\n    \"done\": \"Connection to Steam servers successful\"\r\n}",
@@ -32,81 +33,17 @@
     },
     "variables": [
         {
-            "name": "Map",
-            "description": "The default map for the server.\r\nExamples:\r\n\r\nBomb:\r\nde_dust2, de_mirage, de_nuke, de_overpass, de_inferno, de_ancient, de_vertigo, de_anubis\r\n\r\nHostage:\r\ncs_italy, cs_office\r\n\r\nArms Race:\r\nar_baggage, ar_shoots",
-            "env_variable": "SRCDS_MAP",
-            "default_value": "de_dust2",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": "required|string",
-            "sort": null,
-            "field_type": "text"
-        },
-        {
-            "name": "Source AppID",
-            "description": "Required for game to update on server restart. Do not modify this.",
-            "env_variable": "SRCDS_APPID",
-            "default_value": "730",
-            "user_viewable": false,
-            "user_editable": false,
-            "rules": "required|string|in:730",
-            "sort": null,
-            "field_type": "text"
-        },
-        {
-            "name": "Max Players",
-            "description": "Specifies the maximum amount of players that are able to join the server.",
-            "env_variable": "MAX_PLAYERS",
-            "default_value": "12",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": "required|numeric|between:1,64",
-            "sort": null,
-            "field_type": "text"
-        },
-        {
             "name": "Auto-update server",
             "description": "This is to enable \/ disable auto-updating your server on restart.\r\n\r\nBy default this is set to enabled.",
             "env_variable": "AUTO_UPDATE",
             "default_value": "1",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|boolean",
-            "sort": null,
-            "field_type": "text"
-        },
-        {
-            "name": "SourceTV Port",
-            "description": "SourceTV port used for connections to spectates games on your server.",
-            "env_variable": "TV_PORT",
-            "default_value": "27020",
-            "user_viewable": true,
-            "user_editable": false,
-            "rules": "required|integer|between:1025,65535",
-            "sort": null,
-            "field_type": "text"
-        },
-        {
-            "name": "Steam Gameserver Login Token",
-            "description": "The Steam Account Token required for the server to be displayed public. The token can be acquired here: https:\/\/steamcommunity.com\/dev\/managegameservers",
-            "env_variable": "STEAM_GSLT",
-            "default_value": "",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": "required|string|alpha_num|size:32",
-            "sort": null,
-            "field_type": "text"
-        },
-        {
-            "name": "Enable VAC",
-            "description": "Enable \/ Disable VAC (Valve Anti Cheat) on your server. By default this will be enabled.",
-            "env_variable": "VAC_ENABLED",
-            "default_value": "1",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": "required|boolean",
-            "sort": null,
-            "field_type": "text"
+            "rules": [
+                "required",
+                "boolean"
+            ],
+            "sort": 1
         },
         {
             "name": "Enable RCON",
@@ -115,42 +52,24 @@
             "default_value": "0",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|boolean",
-            "sort": null,
-            "field_type": "text"
+            "rules": [
+                "required",
+                "boolean"
+            ],
+            "sort": 2
         },
         {
-            "name": "Server Name",
-            "description": "Sets the server name listed in the steam server browser.",
-            "env_variable": "SERVER_NAME",
-            "default_value": "A Pterodactyl hosted CS2 Server",
+            "name": "Enable VAC",
+            "description": "Enable \/ Disable VAC (Valve Anti Cheat) on your server. By default this will be enabled.",
+            "env_variable": "VAC_ENABLED",
+            "default_value": "1",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string|max:64",
-            "sort": null,
-            "field_type": "text"
-        },
-        {
-            "name": "Server Password",
-            "description": "If specified, players must provide this password to join the server.",
-            "env_variable": "SERVER_PASSWORD",
-            "default_value": "",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": "nullable|alpha_dash|between:1,30",
-            "sort": null,
-            "field_type": "text"
-        },
-        {
-            "name": "RCON Password",
-            "description": "To gain access to administrator commands on the server.",
-            "env_variable": "RCON_PASSWORD",
-            "default_value": "",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": "required|alpha_dash|between:1,30",
-            "sort": null,
-            "field_type": "text"
+            "rules": [
+                "required",
+                "boolean"
+            ],
+            "sort": 3
         },
         {
             "name": "Gamemode",
@@ -159,9 +78,11 @@
             "default_value": "1",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string",
-            "sort": null,
-            "field_type": "text"
+            "rules": [
+                "required",
+                "string"
+            ],
+            "sort": 4
         },
         {
             "name": "Gametype",
@@ -170,9 +91,123 @@
             "default_value": "0",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string",
-            "sort": null,
-            "field_type": "text"
+            "rules": [
+                "required",
+                "string"
+            ],
+            "sort": 5
+        },
+        {
+            "name": "Map",
+            "description": "The default map for the server.\r\nExamples:\r\n\r\nBomb:\r\nde_dust2, de_mirage, de_nuke, de_overpass, de_inferno, de_ancient, de_vertigo, de_anubis\r\n\r\nHostage:\r\ncs_italy, cs_office\r\n\r\nArms Race:\r\nar_baggage, ar_shoots",
+            "env_variable": "SRCDS_MAP",
+            "default_value": "de_dust2",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "required",
+                "string"
+            ],
+            "sort": 6
+        },
+        {
+            "name": "Max Players",
+            "description": "Specifies the maximum amount of players that are able to join the server.",
+            "env_variable": "MAX_PLAYERS",
+            "default_value": "12",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "required",
+                "numeric",
+                "between:1,64"
+            ],
+            "sort": 7
+        },
+        {
+            "name": "RCON Password",
+            "description": "To gain access to administrator commands on the server.",
+            "env_variable": "RCON_PASSWORD",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "required",
+                "alpha_dash",
+                "between:1,30"
+            ],
+            "sort": 8
+        },
+        {
+            "name": "Server Name",
+            "description": "Sets the server name listed in the steam server browser.",
+            "env_variable": "SERVER_NAME",
+            "default_value": "A Pterodactyl hosted CS2 Server",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "required",
+                "string",
+                "max:64"
+            ],
+            "sort": 9
+        },
+        {
+            "name": "Server Password",
+            "description": "If specified, players must provide this password to join the server.",
+            "env_variable": "SERVER_PASSWORD",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "nullable",
+                "alpha_dash",
+                "between:1,30"
+            ],
+            "sort": 10
+        },
+        {
+            "name": "Source AppID",
+            "description": "Required for game to update on server restart. Do not modify this.",
+            "env_variable": "SRCDS_APPID",
+            "default_value": "730",
+            "user_viewable": false,
+            "user_editable": false,
+            "rules": [
+                "required",
+                "string",
+                "in:730"
+            ],
+            "sort": 11
+        },
+        {
+            "name": "SourceTV Port",
+            "description": "SourceTV port used for connections to spectates games on your server.",
+            "env_variable": "TV_PORT",
+            "default_value": "27020",
+            "user_viewable": true,
+            "user_editable": false,
+            "rules": [
+                "required",
+                "integer",
+                "between:1025,65535"
+            ],
+            "sort": 12
+        },
+        {
+            "name": "Steam Gameserver Login Token",
+            "description": "The Steam Account Token required for the server to be displayed public. The token can be acquired here: https:\/\/steamcommunity.com\/dev\/managegameservers",
+            "env_variable": "STEAM_GSLT",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "required",
+                "string",
+                "alpha_num",
+                "size:32"
+            ],
+            "sort": 13
         }
     ]
 }

--- a/counter_strike/counter_strike_2/egg-counter--strike2.json
+++ b/counter_strike/counter_strike_2/egg-counter--strike2.json
@@ -16,7 +16,7 @@
         "ghcr.io\/parkervcp\/steamcmd:sniper": "ghcr.io\/parkervcp\/steamcmd:sniper"
     },
     "file_denylist": [],
-    "startup": ".\/game\/cs2.sh -dedicated $( [ \"$VAC_ENABLED\" == \"1\" ] || printf %s ' -insecure' ) -ip 0.0.0.0 -port {{SERVER_PORT}} -tv_port {{TV_PORT}} -maxplayers {{MAX_PLAYERS}} $( [ \"$RCON_ENABLED\" == \"0\" ] || printf %s ' -usercon' ) +game_mode {{GAME_MODE}} +game_type {{GAME_TYPE}} +map {{SRCDS_MAP}} +hostname \"{{SERVER_NAME}}\" +sv_password \"{{SERVER_PASSWORD}}\" +rcon_password \"{{RCON_PASSWORD}}\" +sv_setsteamaccount {{STEAM_GSLT}}",
+    "startup": ".\/game\/bin\/linuxsteamrt64\/cs2 -dedicated $( [ \"$VAC_ENABLED\" == \"1\" ] || printf %s ' -insecure' ) -ip 0.0.0.0 -port {{SERVER_PORT}} -tv_port {{TV_PORT}} -maxplayers {{MAX_PLAYERS}} $( [ \"$RCON_ENABLED\" == \"0\" ] || printf %s ' -usercon' ) +game_mode {{GAME_MODE}} +game_type {{GAME_TYPE}} +map {{SRCDS_MAP}} +hostname \"{{SERVER_NAME}}\" +sv_password \"{{SERVER_PASSWORD}}\" +rcon_password \"{{RCON_PASSWORD}}\" +sv_setsteamaccount {{STEAM_GSLT}}",
     "config": {
         "files": "{}",
         "startup": "{\r\n    \"done\": \"Connection to Steam servers successful\"\r\n}",

--- a/counter_strike/counter_strike_2/egg-counter--strike2.json
+++ b/counter_strike/counter_strike_2/egg-counter--strike2.json
@@ -1,15 +1,14 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
-        "version": "PLCN_v1",
+        "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2025-10-04T16:04:33+00:00",
+    "exported_at": "2024-06-01T00:04:01+00:00",
     "name": "Counter-Strike 2",
     "author": "admin@ballaual.de",
     "uuid": "d2991753-0db4-4b68-9f5d-11f997019b78",
     "description": "For over two decades, Counter-Strike has offered an elite competitive experience, one shaped by millions of players from across the globe. And now the next chapter in the CS story is about to begin. This is Counter-Strike 2.",
-    "tags": [],
     "features": [
         "steam_disk_space"
     ],
@@ -17,7 +16,7 @@
         "ghcr.io\/parkervcp\/steamcmd:sniper": "ghcr.io\/parkervcp\/steamcmd:sniper"
     },
     "file_denylist": [],
-    "startup": ".\/game\/cs2.sh -dedicated $( [ \"$VAC_ENABLED\" == \"1\" ] || printf %s ' -insecure' ) -ip 0.0.0.0 -port {{SERVER_PORT}} -tv_port {{TV_PORT}} -maxplayers {{MAX_PLAYERS}} $( [ \"$RCON_ENABLED\" == \"0\" ] || printf %s ' -usercon' ) +game_mode {{GAME_MODE}} +game_type {{GAME_TYPE}} +map {{SRCDS_MAP}} +hostname \"{{SERVER_NAME}}\" +sv_password \"{{SERVER_PASSWORD}}\" +rcon_password \"{{RCON_PASSWORD}}\" +sv_setsteamaccount {{STEAM_GSLT}}",
+    "startup": ".\/game\/bin\/linuxsteamrt64\/cs2 -dedicated $( [ \"$VAC_ENABLED\" == \"1\" ] || printf %s ' -insecure' ) -ip 0.0.0.0 -port {{SERVER_PORT}} -tv_port {{TV_PORT}} -maxplayers {{MAX_PLAYERS}} $( [ \"$RCON_ENABLED\" == \"0\" ] || printf %s ' -usercon' ) +game_mode {{GAME_MODE}} +game_type {{GAME_TYPE}} +map {{SRCDS_MAP}} +hostname \"{{SERVER_NAME}}\" +sv_password \"{{SERVER_PASSWORD}}\" +rcon_password \"{{RCON_PASSWORD}}\" +sv_setsteamaccount {{STEAM_GSLT}}",
     "config": {
         "files": "{}",
         "startup": "{\r\n    \"done\": \"Connection to Steam servers successful\"\r\n}",
@@ -33,138 +32,15 @@
     },
     "variables": [
         {
-            "name": "Auto-update server",
-            "description": "This is to enable \/ disable auto-updating your server on restart.\r\n\r\nBy default this is set to enabled.",
-            "env_variable": "AUTO_UPDATE",
-            "default_value": "1",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": [
-                "required",
-                "boolean"
-            ],
-            "sort": 1
-        },
-        {
-            "name": "Enable RCON",
-            "description": "Enable \/ Disable RCON for using RCON commands with external tools. By default this will be disabled.",
-            "env_variable": "RCON_ENABLED",
-            "default_value": "0",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": [
-                "required",
-                "boolean"
-            ],
-            "sort": 2
-        },
-        {
-            "name": "Enable VAC",
-            "description": "Enable \/ Disable VAC (Valve Anti Cheat) on your server. By default this will be enabled.",
-            "env_variable": "VAC_ENABLED",
-            "default_value": "1",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": [
-                "required",
-                "boolean"
-            ],
-            "sort": 3
-        },
-        {
-            "name": "Gamemode",
-            "description": "Defines the Gamemode and Gametype to be set at the start of the next round.\r\nExamples:\r\n\r\nCompetitive:\r\ngame_mode 1\r\ngame_type 0\r\n\r\nWingman:\r\ngame_mode 2\r\ngame_type 0\r\n\r\nCasual:\r\ngame_mode 0\r\ngame_type 0\r\n\r\nDeathmatch:\r\ngame_mode 2\r\ngame_type 1\r\n\r\nArms Race:\r\ngame_mode 0\r\ngame_type 1\r\n\r\nCustom:\r\ngame_mode 0\r\ngame_type 3",
-            "env_variable": "GAME_MODE",
-            "default_value": "1",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": [
-                "required",
-                "string"
-            ],
-            "sort": 4
-        },
-        {
-            "name": "Gametype",
-            "description": "Defines the Gamemode and Gametype to be set at the start of the next round.\r\nExamples:\r\n\r\nCompetitive:\r\ngame_mode 1\r\ngame_type 0\r\n\r\nWingman:\r\ngame_mode 2\r\ngame_type 0\r\n\r\nCasual:\r\ngame_mode 0\r\ngame_type 0\r\n\r\nDeathmatch:\r\ngame_mode 2\r\ngame_type 1\r\n\r\nArms Race:\r\ngame_mode 0\r\ngame_type 1\r\n\r\nCustom:\r\ngame_mode 0\r\ngame_type 3",
-            "env_variable": "GAME_TYPE",
-            "default_value": "0",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": [
-                "required",
-                "string"
-            ],
-            "sort": 5
-        },
-        {
             "name": "Map",
             "description": "The default map for the server.\r\nExamples:\r\n\r\nBomb:\r\nde_dust2, de_mirage, de_nuke, de_overpass, de_inferno, de_ancient, de_vertigo, de_anubis\r\n\r\nHostage:\r\ncs_italy, cs_office\r\n\r\nArms Race:\r\nar_baggage, ar_shoots",
             "env_variable": "SRCDS_MAP",
             "default_value": "de_dust2",
             "user_viewable": true,
             "user_editable": true,
-            "rules": [
-                "required",
-                "string"
-            ],
-            "sort": 6
-        },
-        {
-            "name": "Max Players",
-            "description": "Specifies the maximum amount of players that are able to join the server.",
-            "env_variable": "MAX_PLAYERS",
-            "default_value": "12",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": [
-                "required",
-                "numeric",
-                "between:1,64"
-            ],
-            "sort": 7
-        },
-        {
-            "name": "RCON Password",
-            "description": "To gain access to administrator commands on the server.",
-            "env_variable": "RCON_PASSWORD",
-            "default_value": "",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": [
-                "required",
-                "alpha_dash",
-                "between:1,30"
-            ],
-            "sort": 8
-        },
-        {
-            "name": "Server Name",
-            "description": "Sets the server name listed in the steam server browser.",
-            "env_variable": "SERVER_NAME",
-            "default_value": "A Pterodactyl hosted CS2 Server",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": [
-                "required",
-                "string",
-                "max:64"
-            ],
-            "sort": 9
-        },
-        {
-            "name": "Server Password",
-            "description": "If specified, players must provide this password to join the server.",
-            "env_variable": "SERVER_PASSWORD",
-            "default_value": "",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": [
-                "nullable",
-                "alpha_dash",
-                "between:1,30"
-            ],
-            "sort": 10
+            "rules": "required|string",
+            "sort": null,
+            "field_type": "text"
         },
         {
             "name": "Source AppID",
@@ -173,12 +49,31 @@
             "default_value": "730",
             "user_viewable": false,
             "user_editable": false,
-            "rules": [
-                "required",
-                "string",
-                "in:730"
-            ],
-            "sort": 11
+            "rules": "required|string|in:730",
+            "sort": null,
+            "field_type": "text"
+        },
+        {
+            "name": "Max Players",
+            "description": "Specifies the maximum amount of players that are able to join the server.",
+            "env_variable": "MAX_PLAYERS",
+            "default_value": "12",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|numeric|between:1,64",
+            "sort": null,
+            "field_type": "text"
+        },
+        {
+            "name": "Auto-update server",
+            "description": "This is to enable \/ disable auto-updating your server on restart.\r\n\r\nBy default this is set to enabled.",
+            "env_variable": "AUTO_UPDATE",
+            "default_value": "1",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|boolean",
+            "sort": null,
+            "field_type": "text"
         },
         {
             "name": "SourceTV Port",
@@ -187,12 +82,9 @@
             "default_value": "27020",
             "user_viewable": true,
             "user_editable": false,
-            "rules": [
-                "required",
-                "integer",
-                "between:1025,65535"
-            ],
-            "sort": 12
+            "rules": "required|integer|between:1025,65535",
+            "sort": null,
+            "field_type": "text"
         },
         {
             "name": "Steam Gameserver Login Token",
@@ -201,13 +93,86 @@
             "default_value": "",
             "user_viewable": true,
             "user_editable": true,
-            "rules": [
-                "required",
-                "string",
-                "alpha_num",
-                "size:32"
-            ],
-            "sort": 13
+            "rules": "required|string|alpha_num|size:32",
+            "sort": null,
+            "field_type": "text"
+        },
+        {
+            "name": "Enable VAC",
+            "description": "Enable \/ Disable VAC (Valve Anti Cheat) on your server. By default this will be enabled.",
+            "env_variable": "VAC_ENABLED",
+            "default_value": "1",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|boolean",
+            "sort": null,
+            "field_type": "text"
+        },
+        {
+            "name": "Enable RCON",
+            "description": "Enable \/ Disable RCON for using RCON commands with external tools. By default this will be disabled.",
+            "env_variable": "RCON_ENABLED",
+            "default_value": "0",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|boolean",
+            "sort": null,
+            "field_type": "text"
+        },
+        {
+            "name": "Server Name",
+            "description": "Sets the server name listed in the steam server browser.",
+            "env_variable": "SERVER_NAME",
+            "default_value": "A Pterodactyl hosted CS2 Server",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string|max:64",
+            "sort": null,
+            "field_type": "text"
+        },
+        {
+            "name": "Server Password",
+            "description": "If specified, players must provide this password to join the server.",
+            "env_variable": "SERVER_PASSWORD",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "nullable|alpha_dash|between:1,30",
+            "sort": null,
+            "field_type": "text"
+        },
+        {
+            "name": "RCON Password",
+            "description": "To gain access to administrator commands on the server.",
+            "env_variable": "RCON_PASSWORD",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|alpha_dash|between:1,30",
+            "sort": null,
+            "field_type": "text"
+        },
+        {
+            "name": "Gamemode",
+            "description": "Defines the Gamemode and Gametype to be set at the start of the next round.\r\nExamples:\r\n\r\nCompetitive:\r\ngame_mode 1\r\ngame_type 0\r\n\r\nWingman:\r\ngame_mode 2\r\ngame_type 0\r\n\r\nCasual:\r\ngame_mode 0\r\ngame_type 0\r\n\r\nDeathmatch:\r\ngame_mode 2\r\ngame_type 1\r\n\r\nArms Race:\r\ngame_mode 0\r\ngame_type 1\r\n\r\nCustom:\r\ngame_mode 0\r\ngame_type 3",
+            "env_variable": "GAME_MODE",
+            "default_value": "1",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string",
+            "sort": null,
+            "field_type": "text"
+        },
+        {
+            "name": "Gametype",
+            "description": "Defines the Gamemode and Gametype to be set at the start of the next round.\r\nExamples:\r\n\r\nCompetitive:\r\ngame_mode 1\r\ngame_type 0\r\n\r\nWingman:\r\ngame_mode 2\r\ngame_type 0\r\n\r\nCasual:\r\ngame_mode 0\r\ngame_type 0\r\n\r\nDeathmatch:\r\ngame_mode 2\r\ngame_type 1\r\n\r\nArms Race:\r\ngame_mode 0\r\ngame_type 1\r\n\r\nCustom:\r\ngame_mode 0\r\ngame_type 3",
+            "env_variable": "GAME_TYPE",
+            "default_value": "0",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string",
+            "sort": null,
+            "field_type": "text"
         }
     ]
 }

--- a/counter_strike/counter_strike_2/egg-pterodactyl-counter--strike2.json
+++ b/counter_strike/counter_strike_2/egg-pterodactyl-counter--strike2.json
@@ -15,7 +15,7 @@
         "ghcr.io/parkervcp/steamcmd:sniper": "ghcr.io/parkervcp/steamcmd:sniper"
     },
     "file_denylist": [],
-    "startup": "./game/bin/linuxsteamrt64/cs2 -dedicated $( [ \"$VAC_ENABLED\" == \"1\" ] || printf %s ' -insecure' ) -ip 0.0.0.0 -port {{SERVER_PORT}} -tv_port {{TV_PORT}} -maxplayers {{MAX_PLAYERS}} $( [ \"$RCON_ENABLED\" == \"0\" ] || printf %s ' -usercon' ) +game_mode {{GAME_MODE}} +game_type {{GAME_TYPE}} +map {{SRCDS_MAP}} +hostname \"{{SERVER_NAME}}\" +sv_password \"{{SERVER_PASSWORD}}\" +rcon_password \"{{RCON_PASSWORD}}\" +sv_setsteamaccount {{STEAM_GSLT}}",
+    "startup": "./game/cs2.sh -dedicated $( [ \"$VAC_ENABLED\" == \"1\" ] || printf %s ' -insecure' ) -ip 0.0.0.0 -port {{SERVER_PORT}} -tv_port {{TV_PORT}} -maxplayers {{MAX_PLAYERS}} $( [ \"$RCON_ENABLED\" == \"0\" ] || printf %s ' -usercon' ) +game_mode {{GAME_MODE}} +game_type {{GAME_TYPE}} +map {{SRCDS_MAP}} +hostname \"{{SERVER_NAME}}\" +sv_password \"{{SERVER_PASSWORD}}\" +rcon_password \"{{RCON_PASSWORD}}\" +sv_setsteamaccount {{STEAM_GSLT}}",
     "config": {
         "files": "{}",
         "logs": "{}",

--- a/counter_strike/counter_strike_2/egg-pterodactyl-counter--strike2.json
+++ b/counter_strike/counter_strike_2/egg-pterodactyl-counter--strike2.json
@@ -15,7 +15,7 @@
         "ghcr.io/parkervcp/steamcmd:sniper": "ghcr.io/parkervcp/steamcmd:sniper"
     },
     "file_denylist": [],
-    "startup": "./game/cs2.sh -dedicated $( [ \"$VAC_ENABLED\" == \"1\" ] || printf %s ' -insecure' ) -ip 0.0.0.0 -port {{SERVER_PORT}} -tv_port {{TV_PORT}} -maxplayers {{MAX_PLAYERS}} $( [ \"$RCON_ENABLED\" == \"0\" ] || printf %s ' -usercon' ) +game_mode {{GAME_MODE}} +game_type {{GAME_TYPE}} +map {{SRCDS_MAP}} +hostname \"{{SERVER_NAME}}\" +sv_password \"{{SERVER_PASSWORD}}\" +rcon_password \"{{RCON_PASSWORD}}\" +sv_setsteamaccount {{STEAM_GSLT}}",
+    "startup": "./game/bin/linuxsteamrt64/cs2 -dedicated $( [ \"$VAC_ENABLED\" == \"1\" ] || printf %s ' -insecure' ) -ip 0.0.0.0 -port {{SERVER_PORT}} -tv_port {{TV_PORT}} -maxplayers {{MAX_PLAYERS}} $( [ \"$RCON_ENABLED\" == \"0\" ] || printf %s ' -usercon' ) +game_mode {{GAME_MODE}} +game_type {{GAME_TYPE}} +map {{SRCDS_MAP}} +hostname \"{{SERVER_NAME}}\" +sv_password \"{{SERVER_PASSWORD}}\" +rcon_password \"{{RCON_PASSWORD}}\" +sv_setsteamaccount {{STEAM_GSLT}}",
     "config": {
         "files": "{}",
         "logs": "{}",


### PR DESCRIPTION
# Description

The current Counter Strike 2 egg is not working. Valve updated the [official wiki with new guidelines](https://developer.valvesoftware.com/wiki/Counter-Strike_2/Dedicated_Servers#Linux), explicitly stating to use their `game/cs2.sh` instead of the `game/bin/linuxsteamrt64/cs2` binary.

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/pelican-eggs/games-steamcmd/blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- If this is an egg update fill these out -->

* [x] You verify that the start command applied does not use a shell script
  * [x] If some script is needed then it is part of a current yolk or a PR to add one
    * [x] It's provided by Valve itself in the game files distribution
* [x] The egg was exported from the panel