### PR TITLE
fix: copy latest version on valheim bepinex script as startup command

### DIFF
--- a/valheim/valheim_bepinex/egg-pterodactyl-valheim-bep-i-nex.json
+++ b/valheim/valheim_bepinex/egg-pterodactyl-valheim-bep-i-nex.json
@@ -1,10 +1,10 @@
 {
-    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
+    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
-        "update_url": null,
-        "version": "PTDL_v2"
+        "version": "PTDL_v2",
+        "update_url": null
     },
-    "exported_at": "2024-06-01T00:05:04+00:00",
+    "exported_at": "2025-11-02T14:52:14+00:00",
     "name": "Valheim  BepINex",
     "author": "eggs@goover.dev",
     "description": "A brutal exploration and survival game for 1-10 players, set in a procedurally-generated purgatory inspired by viking culture incl the Plugin Framework BepInEx",
@@ -12,32 +12,102 @@
         "steam_disk_space"
     ],
     "docker_images": {
-        "ghcr.io/parkervcp/games:valheim": "ghcr.io/parkervcp/games:valheim"
+        "ghcr.io\/parkervcp\/games:valheim": "ghcr.io\/parkervcp\/games:valheim"
     },
     "file_denylist": [],
-    "startup": "export DOORSTOP_ENABLE=TRUE; export DOORSTOP_INVOKE_DLL_PATH=./BepInEx/core/BepInEx.Preloader.dll; export LD_LIBRARY_PATH=\"./doorstop_libs:$LD_LIBRARY_PATH\"; export LD_PRELOAD=\"libdoorstop_x64.so:$LD_PRELOAD\"; export templdpath=$LD_LIBRARY_PATH; export LD_LIBRARY_PATH=\"./linux64:$LD_LIBRARY_PATH\"; export SteamAppId=892970; export LD_LIBRARY_PATH=$templdpath; ./valheim_server.x86_64 -nographics -batchmode -name \"{{SERVER_NAME}}\" -port {{SERVER_PORT}} -world \"{{WORLD}}\" -password \"{{PASSWORD}}\" -public {{PUBLIC_SERVER}} -saveinterval {{BACKUP_INTERVAL}} -backups {{BACKUP_COUNT}} -backupshort {{BACKUP_SHORTTIME}} -backuplong {{BACKUP_LONGTIME}} $( [[ {{ENABLE_CROSSPLAY}} -eq 1 ]] \u0026\u0026 echo \" -crossplay \") \u003e \u003e(sed -uE \"{{CONSOLE_FILTER}}\") \u0026 trap \"{{STOP}}\" 15; wait $!",
+    "startup": "export DOORSTOP_ENABLED=1; export DOORSTOP_TARGET_ASSEMBLY=.\/BepInEx\/core\/BepInEx.Preloader.dll; export LD_LIBRARY_PATH=\\\".\/doorstop_libs:$LD_LIBRARY_PATH\\\"; export LD_PRELOAD=\\\"libdoorstop_x64.so:$LD_PRELOAD\\\"; export LD_LIBRARY_PATH=\\\".\/linux64:$LD_LIBRARY_PATH\\\"; export SteamAppId=892970; .\\\/valheim_server.x86_64 -nographics -batchmode -name \\\"{{SERVER_NAME}}\\\" -port {{SERVER_PORT}} -world \\\"{{WORLD}}\\\" -password \\\"{{PASSWORD}}\\\" -public {{PUBLIC_SERVER}} -saveinterval {{BACKUP_INTERVAL}} -backups {{BACKUP_COUNT}} -backupshort {{BACKUP_SHORTTIME}} -backuplong {{BACKUP_LONGTIME}} $( [[ {{ENABLE_CROSSPLAY}} -eq 1 ]] && echo \\\" -crossplay \\\") > >(sed -uE \\\"{{CONSOLE_FILTER}}\\\") & trap \\\"{{STOP}}\\\" 15; wait $!",
     "config": {
         "files": "{}",
+        "startup": "{\n    \"done\": \"Game server connected\"\n}",
         "logs": "{}",
-        "startup": "{\r\n    \"done\": \"Game server connected\"\r\n}",
         "stop": "^C"
     },
     "scripts": {
         "installation": {
-            "container": "ghcr.io/parkervcp/installers:debian",
-            "entrypoint": "bash",
-            "script": "#!/bin/bash\r\n# Valheim Installation Script\r\n#\r\n# Server Files: /mnt/server\r\n# Image to install with is 'debian:buster-slim'\r\napt -y update\r\napt -y --no-install-recommends --no-install-suggests install wget\r\n\r\n## just in case someone removed the defaults.\r\nif [ \"${STEAM_USER}\" == \"\" ]; then\r\n    echo -e \"steam user is not set.\\n\"\r\n    echo -e \"Using anonymous user.\\n\"\r\n    STEAM_USER=anonymous\r\n    STEAM_PASS=\"\"\r\n    STEAM_AUTH=\"\"\r\nelse\r\n    echo -e \"user set to ${STEAM_USER}\"\r\nfi\r\n\r\n## download and install steamcmd\r\ncd /tmp\r\nmkdir -p /mnt/server/steamcmd\r\ncurl -sSL -o steamcmd.tar.gz https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz\r\ntar -xzvf steamcmd.tar.gz -C /mnt/server/steamcmd\r\ncd /mnt/server/steamcmd\r\n\r\n# SteamCMD fails otherwise for some reason, even running as root.\r\n# This is changed at the end of the install process anyways.\r\nchown -R root:root /mnt\r\nexport HOME=/mnt/server\r\n\r\n## install game using steamcmd\r\n./steamcmd.sh +force_install_dir /mnt/server +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} +app_update ${SRCDS_APPID} ${EXTRA_FLAGS} +quit\r\n\r\n## set up 32 bit libraries\r\nmkdir -p /mnt/server/.steam/sdk32\r\ncp -v linux32/steamclient.so ../.steam/sdk32/steamclient.so\r\n\r\n## set up 64 bit libraries\r\nmkdir -p /mnt/server/.steam/sdk64\r\ncp -v linux64/steamclient.so ../.steam/sdk64/steamclient.so\r\n\r\necho \"-------------------------------------------------------\"\r\necho \"installing BepInEx and Selected ModPacks...\"\r\necho \"-------------------------------------------------------\"\r\nif ! api_response=$(curl -sfSL -H \"accept: application/json\" \"https://thunderstore.io/api/experimental/package/denikson/BepInExPack_Valheim/\"); then\r\n        fatal \"Error: could not retrieve BepInEx release info from Thunderstore.io API\"\r\nfi\r\n\r\ndownload_url=$(jq -r  \".latest.download_url\" \u003c\u003c\u003c \"$api_response\" )\r\nversion_number=$(jq -r  \".latest.version_number\" \u003c\u003c\u003c \"$api_response\" )\r\n\r\nif [ ! -z \"$V_MODPACK\" ]\r\nthen\r\n#Modpack Name dashes to slashes for URL\r\nV_MODPACK=$(echo \"$V_MODPACK\" | sed 's/-/\\//g')\r\n\r\n#Extract dependencies from ModPack JSON data\r\nV_MODPACK_DEPENDENCIES=$(curl -sfSL -H \"accept: application/json\" \"https://thunderstore.io/api/experimental/package/${V_MODPACK}\" | jq -r '.dependencies[]')\r\nfi\r\n\r\ncd /mnt/server\r\n#echo $download_url\r\nwget --content-disposition $download_url\r\nunzip -o denikson-BepInExPack_Valheim-${version_number}.zip\r\ncp -r /mnt/server/BepInExPack_Valheim/* /mnt/server\r\n\r\nif [ ! -z \"$V_MODPACK\" ]\r\nthen\r\n#Delete Old Mods\r\nrm -rf /mnt/server/BepInEx/plugins/*\r\n\r\n#Download and extract the modpack dlls files\r\nfor V_MODPACK_DEPENDENCY in $V_MODPACK_DEPENDENCIES; do\r\n  #ignore bepinex\r\n  if [[ \"$V_MODPACK_DEPENDENCY\" == *\"denikson-BepInExPack_Valheim\"* ]]; then\r\n    continue  # Skip this dependency\r\n  fi\r\n  \r\n  #replace dashes with slashes for url\r\n  V_MODPACK_DEPENDENCY_WITH_SLASH=$(echo \"$V_MODPACK_DEPENDENCY\" | sed 's/-/\\//g')\r\n  \r\n  #download dependencies\r\n  wget -O \"$V_MODPACK_DEPENDENCY.zip\" \"https://thunderstore.io/package/download/$V_MODPACK_DEPENDENCY_WITH_SLASH\"\r\n\r\n  #Set the destination directory and ensure it exists\r\n  destination_directory=\"/mnt/server/BepInEx/plugins\"\r\n  if [ ! -d \"$destination_directory\" ]; then\r\n    mkdir -p \"$destination_directory\"\r\n  fi\r\n\r\n  #Extract DLL files from the ZIP and delete the zip file\r\n  unzip -j \"$V_MODPACK_DEPENDENCY.zip\" \"*.dll\" -d \"$destination_directory\"\r\n  \r\n  #Cleanup\r\n  rm $V_MODPACK_DEPENDENCY.zip\r\ndone\r\nfi\r\n\r\n##cleanup\r\necho \"-------------------------------------------------------\"\r\necho \"cleanup files...\"\r\necho \"-------------------------------------------------------\"\r\nrm -fR BepInExPack_Valheim\r\nrm -fR icon.png\r\nrm -fR denikson-BepInExPack_Valheim-*\r\nrm -fR manifest.json\r\nrm -fR README.m\r\n\r\n#rm -fR start_*\r\n\r\necho \"-------------------------------------------------------\"\r\necho \"Installation completed\"\r\necho \"-------------------------------------------------------\""
+            "script": "#!\/bin\/bash\r\n# Valheim Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\n# Image to install with is 'debian:buster-slim'\r\napt -y update\r\napt -y --no-install-recommends --no-install-suggests install wget\r\n\r\n## just in case someone removed the defaults.\r\nif [ \"${STEAM_USER}\" == \"\" ]; then\r\n    echo -e \"steam user is not set.\\n\"\r\n    echo -e \"Using anonymous user.\\n\"\r\n    STEAM_USER=anonymous\r\n    STEAM_PASS=\"\"\r\n    STEAM_AUTH=\"\"\r\nelse\r\n    echo -e \"user set to ${STEAM_USER}\"\r\nfi\r\n\r\n## download and install steamcmd\r\ncd \/tmp\r\nmkdir -p \/mnt\/server\/steamcmd\r\ncurl -sSL -o steamcmd.tar.gz https:\/\/steamcdn-a.akamaihd.net\/client\/installer\/steamcmd_linux.tar.gz\r\ntar -xzvf steamcmd.tar.gz -C \/mnt\/server\/steamcmd\r\ncd \/mnt\/server\/steamcmd\r\n\r\n# SteamCMD fails otherwise for some reason, even running as root.\r\n# This is changed at the end of the install process anyways.\r\nchown -R root:root \/mnt\r\nexport HOME=\/mnt\/server\r\n\r\n## install game using steamcmd\r\n.\/steamcmd.sh +force_install_dir \/mnt\/server +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} +app_update ${SRCDS_APPID} ${EXTRA_FLAGS} +quit\r\n\r\n## set up 32 bit libraries\r\nmkdir -p \/mnt\/server\/.steam\/sdk32\r\ncp -v linux32\/steamclient.so ..\/.steam\/sdk32\/steamclient.so\r\n\r\n## set up 64 bit libraries\r\nmkdir -p \/mnt\/server\/.steam\/sdk64\r\ncp -v linux64\/steamclient.so ..\/.steam\/sdk64\/steamclient.so\r\n\r\necho \"-------------------------------------------------------\"\r\necho \"installing BepInEx and Selected ModPacks...\"\r\necho \"-------------------------------------------------------\"\r\nif ! api_response=$(curl -sfSL -H \"accept: application\/json\" \"https:\/\/thunderstore.io\/api\/experimental\/package\/denikson\/BepInExPack_Valheim\/\"); then\r\n        fatal \"Error: could not retrieve BepInEx release info from Thunderstore.io API\"\r\nfi\r\n\r\ndownload_url=$(jq -r  \".latest.download_url\" <<< \"$api_response\" )\r\nversion_number=$(jq -r  \".latest.version_number\" <<< \"$api_response\" )\r\n\r\nif [ ! -z \"$V_MODPACK\" ]\r\nthen\r\n#Modpack Name dashes to slashes for URL\r\nV_MODPACK=$(echo \"$V_MODPACK\" | sed 's\/-\/\\\/\/g')\r\n\r\n#Extract dependencies from ModPack JSON data\r\nV_MODPACK_DEPENDENCIES=$(curl -sfSL -H \"accept: application\/json\" \"https:\/\/thunderstore.io\/api\/experimental\/package\/${V_MODPACK}\" | jq -r '.dependencies[]')\r\nfi\r\n\r\ncd \/mnt\/server\r\n#echo $download_url\r\nwget --content-disposition $download_url\r\nunzip -o denikson-BepInExPack_Valheim-${version_number}.zip\r\ncp -r \/mnt\/server\/BepInExPack_Valheim\/* \/mnt\/server\r\n\r\nif [ ! -z \"$V_MODPACK\" ]\r\nthen\r\n#Delete Old Mods\r\nrm -rf \/mnt\/server\/BepInEx\/plugins\/*\r\n\r\n#Download and extract the modpack dlls files\r\nfor V_MODPACK_DEPENDENCY in $V_MODPACK_DEPENDENCIES; do\r\n  #ignore bepinex\r\n  if [[ \"$V_MODPACK_DEPENDENCY\" == *\"denikson-BepInExPack_Valheim\"* ]]; then\r\n    continue  # Skip this dependency\r\n  fi\r\n  \r\n  #replace dashes with slashes for url\r\n  V_MODPACK_DEPENDENCY_WITH_SLASH=$(echo \"$V_MODPACK_DEPENDENCY\" | sed 's\/-\/\\\/\/g')\r\n  \r\n  #download dependencies\r\n  wget -O \"$V_MODPACK_DEPENDENCY.zip\" \"https:\/\/thunderstore.io\/package\/download\/$V_MODPACK_DEPENDENCY_WITH_SLASH\"\r\n\r\n  #Set the destination directory and ensure it exists\r\n  destination_directory=\"\/mnt\/server\/BepInEx\/plugins\"\r\n  if [ ! -d \"$destination_directory\" ]; then\r\n    mkdir -p \"$destination_directory\"\r\n  fi\r\n\r\n  #Extract DLL files from the ZIP and delete the zip file\r\n  unzip -j \"$V_MODPACK_DEPENDENCY.zip\" \"*.dll\" -d \"$destination_directory\"\r\n  \r\n  #Cleanup\r\n  rm $V_MODPACK_DEPENDENCY.zip\r\ndone\r\nfi\r\n\r\n##cleanup\r\necho \"-------------------------------------------------------\"\r\necho \"cleanup files...\"\r\necho \"-------------------------------------------------------\"\r\nrm -fR BepInExPack_Valheim\r\nrm -fR icon.png\r\nrm -fR denikson-BepInExPack_Valheim-*\r\nrm -fR manifest.json\r\nrm -fR README.m\r\n\r\n#rm -fR start_*\r\n\r\necho \"-------------------------------------------------------\"\r\necho \"Installation completed\"\r\necho \"-------------------------------------------------------\"",
+            "container": "ghcr.io\/parkervcp\/installers:debian",
+            "entrypoint": "bash"
         }
     },
     "variables": [
         {
-            "name": "Server Name",
-            "description": "Name that appears in server browser.",
-            "env_variable": "SERVER_NAME",
-            "default_value": "My Server",
+            "name": "Auto Update",
+            "description": "",
+            "env_variable": "AUTO_UPDATE",
+            "default_value": "1",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string|max:60",
+            "rules": "required|boolean",
+            "field_type": "text"
+        },
+        {
+            "name": "Backup Count",
+            "description": "Sets how many automatic backups will be kept. The first is the 'short' backup length, and the rest are the 'long' backup length. When default values are used means one backup that is 2 hours old, and 3 backups that are 12 hours apart. Default: 4.",
+            "env_variable": "BACKUP_COUNT",
+            "default_value": "4",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|numeric|min:0",
+            "field_type": "text"
+        },
+        {
+            "name": "Backup Interval",
+            "description": "Change how often the world will save in seconds. Default: 1800 (30 minutes).",
+            "env_variable": "BACKUP_INTERVAL",
+            "default_value": "1800",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|numeric|min:0",
+            "field_type": "text"
+        },
+        {
+            "name": "Backup Longtime",
+            "description": "Sets the interval between the subsequent automatic backups in seconds. Default: 43200 (12 hours).",
+            "env_variable": "BACKUP_LONGTIME",
+            "default_value": "43200",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|numeric|min:0",
+            "field_type": "text"
+        },
+        {
+            "name": "Backup Shorttime",
+            "description": "Sets the interval between the first automatic backups in seconds. Default: 7200 (2 hours).",
+            "env_variable": "BACKUP_SHORTTIME",
+            "default_value": "7200",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|numeric|min:0",
+            "field_type": "text"
+        },
+        {
+            "name": "[System] Console Filter",
+            "description": "Remove unwanted outputs from the console.",
+            "env_variable": "CONSOLE_FILTER",
+            "default_value": "\/^\\(Filename:.*Line:[[:space:]]+[[:digit:]]+\\)$\/d; \/^([[:space:]]+)?$\/d",
+            "user_viewable": false,
+            "user_editable": false,
+            "rules": "string",
+            "field_type": "text"
+        },
+        {
+            "name": "Enable Crossplay",
+            "description": "Enable crossplay support",
+            "env_variable": "ENABLE_CROSSPLAY",
+            "default_value": "0",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|boolean",
+            "field_type": "text"
+        },
+        {
+            "name": "[System] LD Library Path",
+            "description": "Required to load server libraries.",
+            "env_variable": "LD_LIBRARY_PATH",
+            "default_value": ".\/linux64",
+            "user_viewable": false,
+            "user_editable": false,
+            "rules": "required|string",
             "field_type": "text"
         },
         {
@@ -51,16 +121,6 @@
             "field_type": "text"
         },
         {
-            "name": "World Name",
-            "description": "Name to load if switching between multiple saved worlds.",
-            "env_variable": "WORLD",
-            "default_value": "Dedicated",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": "required|string|max:20",
-            "field_type": "text"
-        },
-        {
             "name": "Public Server",
             "description": "",
             "env_variable": "PUBLIC_SERVER",
@@ -71,23 +131,23 @@
             "field_type": "text"
         },
         {
-            "name": "Auto Update",
-            "description": "",
-            "env_variable": "AUTO_UPDATE",
-            "default_value": "1",
+            "name": "Server Name",
+            "description": "Name that appears in server browser.",
+            "env_variable": "SERVER_NAME",
+            "default_value": "My Server",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|boolean",
+            "rules": "required|string|max:60",
             "field_type": "text"
         },
         {
-            "name": "Enable Crossplay",
-            "description": "Enable crossplay support",
-            "env_variable": "ENABLE_CROSSPLAY",
-            "default_value": "0",
+            "name": "[System] App ID",
+            "description": "Valheim steam app id for auto updates.",
+            "env_variable": "SRCDS_APPID",
+            "default_value": "896660",
             "user_viewable": true,
-            "user_editable": true,
-            "rules": "required|boolean",
+            "user_editable": false,
+            "rules": "nullable|numeric",
             "field_type": "text"
         },
         {
@@ -111,76 +171,6 @@
             "field_type": "text"
         },
         {
-            "name": "Backup Interval",
-            "description": "Change how often the world will save in seconds. Default: 1800 (30 minutes).",
-            "env_variable": "BACKUP_INTERVAL",
-            "default_value": "1800",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": "required|numeric|min:0",
-            "field_type": "text"
-        },
-        {
-            "name": "Backup Count",
-            "description": "Sets how many automatic backups will be kept. The first is the 'short' backup length, and the rest are the 'long' backup length. When default values are used means one backup that is 2 hours old, and 3 backups that are 12 hours apart. Default: 4.",
-            "env_variable": "BACKUP_COUNT",
-            "default_value": "4",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": "required|numeric|min:0",
-            "field_type": "text"
-        },
-        {
-            "name": "Backup Shorttime",
-            "description": "Sets the interval between the first automatic backups in seconds. Default: 7200 (2 hours).",
-            "env_variable": "BACKUP_SHORTTIME",
-            "default_value": "7200",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": "required|numeric|min:0",
-            "field_type": "text"
-        },
-        {
-            "name": "Backup Longtime",
-            "description": "Sets the interval between the subsequent automatic backups in seconds. Default: 43200 (12 hours).",
-            "env_variable": "BACKUP_LONGTIME",
-            "default_value": "43200",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": "required|numeric|min:0",
-            "field_type": "text"
-        },
-        {
-            "name": "[System] Console Filter",
-            "description": "Remove unwanted outputs from the console.",
-            "env_variable": "CONSOLE_FILTER",
-            "default_value": "/^\\(Filename:.*Line:[[:space:]]+[[:digit:]]+\\)$/d; /^([[:space:]]+)?$/d",
-            "user_viewable": false,
-            "user_editable": false,
-            "rules": "string",
-            "field_type": "text"
-        },
-        {
-            "name": "[System] App ID",
-            "description": "Valheim steam app id for auto updates.",
-            "env_variable": "SRCDS_APPID",
-            "default_value": "896660",
-            "user_viewable": true,
-            "user_editable": false,
-            "rules": "nullable|numeric",
-            "field_type": "text"
-        },
-        {
-            "name": "[System] LD Library Path",
-            "description": "Required to load server libraries.",
-            "env_variable": "LD_LIBRARY_PATH",
-            "default_value": "./linux64",
-            "user_viewable": false,
-            "user_editable": false,
-            "rules": "required|string",
-            "field_type": "text"
-        },
-        {
             "name": "[System] Shutdown Command",
             "description": "",
             "env_variable": "STOP",
@@ -198,6 +188,16 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": "string|nullable",
+            "field_type": "text"
+        },
+        {
+            "name": "World Name",
+            "description": "Name to load if switching between multiple saved worlds.",
+            "env_variable": "WORLD",
+            "default_value": "Dedicated",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string|max:20",
             "field_type": "text"
         }
     ]

--- a/valheim/valheim_bepinex/egg-valheim-bep-i-nex.json
+++ b/valheim/valheim_bepinex/egg-valheim-bep-i-nex.json
@@ -1,265 +1,265 @@
 {
-  "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
-  "meta": {
-    "version": "PLCN_v3",
-    "update_url": null
-  },
-  "exported_at": "2025-11-02T13:38:53+00:00",
-  "name": "Valheim  BepINex",
-  "author": "eggs@goover.dev",
-  "uuid": "7cf84d70-b857-4167-b051-ca3e3855c5d7",
-  "description": "A brutal exploration and survival game for 1-10 players, set in a procedurally-generated purgatory inspired by viking culture incl the Plugin Framework BepInEx",
-  "tags": [],
-  "features": [
-    "steam_disk_space"
-  ],
-  "docker_images": {
-    "ghcr.io/parkervcp/games:valheim": "ghcr.io/parkervcp/games:valheim"
-  },
-  "file_denylist": [],
-  "startup_commands": {
-    "Default": "export DOORSTOP_ENABLED=1; export DOORSTOP_TARGET_ASSEMBLY=./BepInEx/core/BepInEx.Preloader.dll; export LD_LIBRARY_PATH=\\\"./doorstop_libs:$LD_LIBRARY_PATH\\\"; export LD_PRELOAD=\\\"libdoorstop_x64.so:$LD_PRELOAD\\\"; export LD_LIBRARY_PATH=\\\"./linux64:$LD_LIBRARY_PATH\\\"; export SteamAppId=892970; .\\/valheim_server.x86_64 -nographics -batchmode -name \\\"{{SERVER_NAME}}\\\" -port {{SERVER_PORT}} -world \\\"{{WORLD}}\\\" -password \\\"{{PASSWORD}}\\\" -public {{PUBLIC_SERVER}} -saveinterval {{BACKUP_INTERVAL}} -backups {{BACKUP_COUNT}} -backupshort {{BACKUP_SHORTTIME}} -backuplong {{BACKUP_LONGTIME}} $( [[ {{ENABLE_CROSSPLAY}} -eq 1 ]] && echo \\\" -crossplay \\\") > >(sed -uE \\\"{{CONSOLE_FILTER}}\\\") & trap \\\"{{STOP}}\\\" 15; wait $!"
-  },
-  "config": {
-    "files": "{}",
-    "startup": "{\n    \"done\": \"Game server connected\"\n}",
-    "logs": "{}",
-    "stop": "^C"
-  },
-  "scripts": {
-    "installation": {
-      "script": "#!/bin/bash\r\n# Valheim Installation Script\r\n#\r\n# Server Files: /mnt/server\r\n# Image to install with is 'debian:buster-slim'\r\napt -y update\r\napt -y --no-install-recommends --no-install-suggests install wget\r\n\r\n## just in case someone removed the defaults.\r\nif [ \"${STEAM_USER}\" == \"\" ]; then\r\n    echo -e \"steam user is not set.\\n\"\r\n    echo -e \"Using anonymous user.\\n\"\r\n    STEAM_USER=anonymous\r\n    STEAM_PASS=\"\"\r\n    STEAM_AUTH=\"\"\r\nelse\r\n    echo -e \"user set to ${STEAM_USER}\"\r\nfi\r\n\r\n## download and install steamcmd\r\ncd /tmp\r\nmkdir -p /mnt/server/steamcmd\r\ncurl -sSL -o steamcmd.tar.gz https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz\r\ntar -xzvf steamcmd.tar.gz -C /mnt/server/steamcmd\r\ncd /mnt/server/steamcmd\r\n\r\n# SteamCMD fails otherwise for some reason, even running as root.\r\n# This is changed at the end of the install process anyways.\r\nchown -R root:root /mnt\r\nexport HOME=/mnt/server\r\n\r\n## install game using steamcmd\r\n./steamcmd.sh +force_install_dir /mnt/server +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} +app_update ${SRCDS_APPID} ${EXTRA_FLAGS} +quit\r\n\r\n## set up 32 bit libraries\r\nmkdir -p /mnt/server/.steam/sdk32\r\ncp -v linux32/steamclient.so ../.steam/sdk32/steamclient.so\r\n\r\n## set up 64 bit libraries\r\nmkdir -p /mnt/server/.steam/sdk64\r\ncp -v linux64/steamclient.so ../.steam/sdk64/steamclient.so\r\n\r\necho \"-------------------------------------------------------\"\r\necho \"installing BepInEx and Selected ModPacks...\"\r\necho \"-------------------------------------------------------\"\r\nif ! api_response=$(curl -sfSL -H \"accept: application/json\" \"https://thunderstore.io/api/experimental/package/denikson/BepInExPack_Valheim/\"); then\r\n        fatal \"Error: could not retrieve BepInEx release info from Thunderstore.io API\"\r\nfi\r\n\r\ndownload_url=$(jq -r  \".latest.download_url\" <<< \"$api_response\" )\r\nversion_number=$(jq -r  \".latest.version_number\" <<< \"$api_response\" )\r\n\r\nif [ ! -z \"$V_MODPACK\" ]\r\nthen\r\n#Modpack Name dashes to slashes for URL\r\nV_MODPACK=$(echo \"$V_MODPACK\" | sed 's/-/\\//g')\r\n\r\n#Extract dependencies from ModPack JSON data\r\nV_MODPACK_DEPENDENCIES=$(curl -sfSL -H \"accept: application/json\" \"https://thunderstore.io/api/experimental/package/${V_MODPACK}\" | jq -r '.dependencies[]')\r\nfi\r\n\r\ncd /mnt/server\r\n#echo $download_url\r\nwget --content-disposition $download_url\r\nunzip -o denikson-BepInExPack_Valheim-${version_number}.zip\r\ncp -r /mnt/server/BepInExPack_Valheim/* /mnt/server\r\n\r\nif [ ! -z \"$V_MODPACK\" ]\r\nthen\r\n#Delete Old Mods\r\nrm -rf /mnt/server/BepInEx/plugins/*\r\n\r\n#Download and extract the modpack dlls files\r\nfor V_MODPACK_DEPENDENCY in $V_MODPACK_DEPENDENCIES; do\r\n  #ignore bepinex\r\n  if [[ \"$V_MODPACK_DEPENDENCY\" == *\"denikson-BepInExPack_Valheim\"* ]]; then\r\n    continue  # Skip this dependency\r\n  fi\r\n  \r\n  #replace dashes with slashes for url\r\n  V_MODPACK_DEPENDENCY_WITH_SLASH=$(echo \"$V_MODPACK_DEPENDENCY\" | sed 's/-/\\//g')\r\n  \r\n  #download dependencies\r\n  wget -O \"$V_MODPACK_DEPENDENCY.zip\" \"https://thunderstore.io/package/download/$V_MODPACK_DEPENDENCY_WITH_SLASH\"\r\n\r\n  #Set the destination directory and ensure it exists\r\n  destination_directory=\"/mnt/server/BepInEx/plugins\"\r\n  if [ ! -d \"$destination_directory\" ]; then\r\n    mkdir -p \"$destination_directory\"\r\n  fi\r\n\r\n  #Extract DLL files from the ZIP and delete the zip file\r\n  unzip -j \"$V_MODPACK_DEPENDENCY.zip\" \"*.dll\" -d \"$destination_directory\"\r\n  \r\n  #Cleanup\r\n  rm $V_MODPACK_DEPENDENCY.zip\r\ndone\r\nfi\r\n\r\n##cleanup\r\necho \"-------------------------------------------------------\"\r\necho \"cleanup files...\"\r\necho \"-------------------------------------------------------\"\r\nrm -fR BepInExPack_Valheim\r\nrm -fR icon.png\r\nrm -fR denikson-BepInExPack_Valheim-*\r\nrm -fR manifest.json\r\nrm -fR README.m\r\n\r\n#rm -fR start_*\r\n\r\necho \"-------------------------------------------------------\"\r\necho \"Installation completed\"\r\necho \"-------------------------------------------------------\"",
-      "container": "ghcr.io/parkervcp/installers:debian",
-      "entrypoint": "bash"
-    }
-  },
-  "variables": [
-    {
-      "name": "Server Password",
-      "description": "Server password.",
-      "env_variable": "PASSWORD",
-      "default_value": "secret",
-      "user_viewable": true,
-      "user_editable": true,
-      "rules": [
-        "required",
-        "string",
-        "min:5",
-        "max:20"
-      ],
-      "sort": 2
+    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
+    "meta": {
+        "version": "PLCN_v3",
+        "update_url": null
     },
-    {
-      "name": "World Name",
-      "description": "Name to load if switching between multiple saved worlds.",
-      "env_variable": "WORLD",
-      "default_value": "Dedicated",
-      "user_viewable": true,
-      "user_editable": true,
-      "rules": [
-        "required",
-        "string",
-        "max:20"
-      ],
-      "sort": 3
+    "exported_at": "2025-11-02T14:52:14+00:00",
+    "name": "Valheim  BepINex",
+    "author": "eggs@goover.dev",
+    "uuid": "7cf84d70-b857-4167-b051-ca3e3855c5d7",
+    "description": "A brutal exploration and survival game for 1-10 players, set in a procedurally-generated purgatory inspired by viking culture incl the Plugin Framework BepInEx",
+    "tags": [],
+    "features": [
+        "steam_disk_space"
+    ],
+    "docker_images": {
+        "ghcr.io/parkervcp/games:valheim": "ghcr.io/parkervcp/games:valheim"
     },
-    {
-      "name": "Public Server",
-      "description": "",
-      "env_variable": "PUBLIC_SERVER",
-      "default_value": "1",
-      "user_viewable": true,
-      "user_editable": true,
-      "rules": [
-        "required",
-        "boolean"
-      ],
-      "sort": 4
+    "file_denylist": [],
+    "startup_commands": {
+        "Default": "export DOORSTOP_ENABLED=1; export DOORSTOP_TARGET_ASSEMBLY=./BepInEx/core/BepInEx.Preloader.dll; export LD_LIBRARY_PATH=\\\"./doorstop_libs:$LD_LIBRARY_PATH\\\"; export LD_PRELOAD=\\\"libdoorstop_x64.so:$LD_PRELOAD\\\"; export LD_LIBRARY_PATH=\\\"./linux64:$LD_LIBRARY_PATH\\\"; export SteamAppId=892970; .\\/valheim_server.x86_64 -nographics -batchmode -name \\\"{{SERVER_NAME}}\\\" -port {{SERVER_PORT}} -world \\\"{{WORLD}}\\\" -password \\\"{{PASSWORD}}\\\" -public {{PUBLIC_SERVER}} -saveinterval {{BACKUP_INTERVAL}} -backups {{BACKUP_COUNT}} -backupshort {{BACKUP_SHORTTIME}} -backuplong {{BACKUP_LONGTIME}} $( [[ {{ENABLE_CROSSPLAY}} -eq 1 ]] && echo \\\" -crossplay \\\") > >(sed -uE \\\"{{CONSOLE_FILTER}}\\\") & trap \\\"{{STOP}}\\\" 15; wait $!"
     },
-    {
-      "name": "Auto Update",
-      "description": "",
-      "env_variable": "AUTO_UPDATE",
-      "default_value": "1",
-      "user_viewable": true,
-      "user_editable": true,
-      "rules": [
-        "required",
-        "boolean"
-      ],
-      "sort": 5
+    "config": {
+        "files": "{}",
+        "startup": "{\n    \"done\": \"Game server connected\"\n}",
+        "logs": "{}",
+        "stop": "^C"
     },
-    {
-      "name": "Enable Crossplay",
-      "description": "Enable crossplay support",
-      "env_variable": "ENABLE_CROSSPLAY",
-      "default_value": "0",
-      "user_viewable": true,
-      "user_editable": true,
-      "rules": [
-        "required",
-        "boolean"
-      ],
-      "sort": 6
+    "scripts": {
+        "installation": {
+            "script": "#!/bin/bash\r\n# Valheim Installation Script\r\n#\r\n# Server Files: /mnt/server\r\n# Image to install with is 'debian:buster-slim'\r\napt -y update\r\napt -y --no-install-recommends --no-install-suggests install wget\r\n\r\n## just in case someone removed the defaults.\r\nif [ \"${STEAM_USER}\" == \"\" ]; then\r\n    echo -e \"steam user is not set.\\n\"\r\n    echo -e \"Using anonymous user.\\n\"\r\n    STEAM_USER=anonymous\r\n    STEAM_PASS=\"\"\r\n    STEAM_AUTH=\"\"\r\nelse\r\n    echo -e \"user set to ${STEAM_USER}\"\r\nfi\r\n\r\n## download and install steamcmd\r\ncd /tmp\r\nmkdir -p /mnt/server/steamcmd\r\ncurl -sSL -o steamcmd.tar.gz https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz\r\ntar -xzvf steamcmd.tar.gz -C /mnt/server/steamcmd\r\ncd /mnt/server/steamcmd\r\n\r\n# SteamCMD fails otherwise for some reason, even running as root.\r\n# This is changed at the end of the install process anyways.\r\nchown -R root:root /mnt\r\nexport HOME=/mnt/server\r\n\r\n## install game using steamcmd\r\n./steamcmd.sh +force_install_dir /mnt/server +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} +app_update ${SRCDS_APPID} ${EXTRA_FLAGS} +quit\r\n\r\n## set up 32 bit libraries\r\nmkdir -p /mnt/server/.steam/sdk32\r\ncp -v linux32/steamclient.so ../.steam/sdk32/steamclient.so\r\n\r\n## set up 64 bit libraries\r\nmkdir -p /mnt/server/.steam/sdk64\r\ncp -v linux64/steamclient.so ../.steam/sdk64/steamclient.so\r\n\r\necho \"-------------------------------------------------------\"\r\necho \"installing BepInEx and Selected ModPacks...\"\r\necho \"-------------------------------------------------------\"\r\nif ! api_response=$(curl -sfSL -H \"accept: application/json\" \"https://thunderstore.io/api/experimental/package/denikson/BepInExPack_Valheim/\"); then\r\n        fatal \"Error: could not retrieve BepInEx release info from Thunderstore.io API\"\r\nfi\r\n\r\ndownload_url=$(jq -r  \".latest.download_url\" <<< \"$api_response\" )\r\nversion_number=$(jq -r  \".latest.version_number\" <<< \"$api_response\" )\r\n\r\nif [ ! -z \"$V_MODPACK\" ]\r\nthen\r\n#Modpack Name dashes to slashes for URL\r\nV_MODPACK=$(echo \"$V_MODPACK\" | sed 's/-/\\//g')\r\n\r\n#Extract dependencies from ModPack JSON data\r\nV_MODPACK_DEPENDENCIES=$(curl -sfSL -H \"accept: application/json\" \"https://thunderstore.io/api/experimental/package/${V_MODPACK}\" | jq -r '.dependencies[]')\r\nfi\r\n\r\ncd /mnt/server\r\n#echo $download_url\r\nwget --content-disposition $download_url\r\nunzip -o denikson-BepInExPack_Valheim-${version_number}.zip\r\ncp -r /mnt/server/BepInExPack_Valheim/* /mnt/server\r\n\r\nif [ ! -z \"$V_MODPACK\" ]\r\nthen\r\n#Delete Old Mods\r\nrm -rf /mnt/server/BepInEx/plugins/*\r\n\r\n#Download and extract the modpack dlls files\r\nfor V_MODPACK_DEPENDENCY in $V_MODPACK_DEPENDENCIES; do\r\n  #ignore bepinex\r\n  if [[ \"$V_MODPACK_DEPENDENCY\" == *\"denikson-BepInExPack_Valheim\"* ]]; then\r\n    continue  # Skip this dependency\r\n  fi\r\n  \r\n  #replace dashes with slashes for url\r\n  V_MODPACK_DEPENDENCY_WITH_SLASH=$(echo \"$V_MODPACK_DEPENDENCY\" | sed 's/-/\\//g')\r\n  \r\n  #download dependencies\r\n  wget -O \"$V_MODPACK_DEPENDENCY.zip\" \"https://thunderstore.io/package/download/$V_MODPACK_DEPENDENCY_WITH_SLASH\"\r\n\r\n  #Set the destination directory and ensure it exists\r\n  destination_directory=\"/mnt/server/BepInEx/plugins\"\r\n  if [ ! -d \"$destination_directory\" ]; then\r\n    mkdir -p \"$destination_directory\"\r\n  fi\r\n\r\n  #Extract DLL files from the ZIP and delete the zip file\r\n  unzip -j \"$V_MODPACK_DEPENDENCY.zip\" \"*.dll\" -d \"$destination_directory\"\r\n  \r\n  #Cleanup\r\n  rm $V_MODPACK_DEPENDENCY.zip\r\ndone\r\nfi\r\n\r\n##cleanup\r\necho \"-------------------------------------------------------\"\r\necho \"cleanup files...\"\r\necho \"-------------------------------------------------------\"\r\nrm -fR BepInExPack_Valheim\r\nrm -fR icon.png\r\nrm -fR denikson-BepInExPack_Valheim-*\r\nrm -fR manifest.json\r\nrm -fR README.m\r\n\r\n#rm -fR start_*\r\n\r\necho \"-------------------------------------------------------\"\r\necho \"Installation completed\"\r\necho \"-------------------------------------------------------\"",
+            "container": "ghcr.io/parkervcp/installers:debian",
+            "entrypoint": "bash"
+        }
     },
-    {
-      "name": "Beta Branch",
-      "description": "",
-      "env_variable": "SRCDS_BETAID",
-      "default_value": "",
-      "user_viewable": true,
-      "user_editable": true,
-      "rules": [
-        "max:30"
-      ],
-      "sort": 7
-    },
-    {
-      "name": "Beta Password",
-      "description": "",
-      "env_variable": "SRCDS_BETAPASS",
-      "default_value": "",
-      "user_viewable": true,
-      "user_editable": true,
-      "rules": [
-        "max:30"
-      ],
-      "sort": 8
-    },
-    {
-      "name": "Backup Interval",
-      "description": "Change how often the world will save in seconds. Default: 1800 (30 minutes).",
-      "env_variable": "BACKUP_INTERVAL",
-      "default_value": "1800",
-      "user_viewable": true,
-      "user_editable": true,
-      "rules": [
-        "required",
-        "numeric",
-        "min:0"
-      ],
-      "sort": 9
-    },
-    {
-      "name": "Backup Count",
-      "description": "Sets how many automatic backups will be kept. The first is the 'short' backup length, and the rest are the 'long' backup length. When default values are used means one backup that is 2 hours old, and 3 backups that are 12 hours apart. Default: 4.",
-      "env_variable": "BACKUP_COUNT",
-      "default_value": "4",
-      "user_viewable": true,
-      "user_editable": true,
-      "rules": [
-        "required",
-        "numeric",
-        "min:0"
-      ],
-      "sort": 10
-    },
-    {
-      "name": "Backup Shorttime",
-      "description": "Sets the interval between the first automatic backups in seconds. Default: 7200 (2 hours).",
-      "env_variable": "BACKUP_SHORTTIME",
-      "default_value": "7200",
-      "user_viewable": true,
-      "user_editable": true,
-      "rules": [
-        "required",
-        "numeric",
-        "min:0"
-      ],
-      "sort": 11
-    },
-    {
-      "name": "Backup Longtime",
-      "description": "Sets the interval between the subsequent automatic backups in seconds. Default: 43200 (12 hours).",
-      "env_variable": "BACKUP_LONGTIME",
-      "default_value": "43200",
-      "user_viewable": true,
-      "user_editable": true,
-      "rules": [
-        "required",
-        "numeric",
-        "min:0"
-      ],
-      "sort": 12
-    },
-    {
-      "name": "[System] Console Filter",
-      "description": "Remove unwanted outputs from the console.",
-      "env_variable": "CONSOLE_FILTER",
-      "default_value": "/^\\(Filename:.*Line:[[:space:]]+[[:digit:]]+\\)$/d; /^([[:space:]]+)?$/d",
-      "user_viewable": false,
-      "user_editable": false,
-      "rules": [
-        "string"
-      ],
-      "sort": 13
-    },
-    {
-      "name": "[System] App ID",
-      "description": "Valheim steam app id for auto updates.",
-      "env_variable": "SRCDS_APPID",
-      "default_value": "896660",
-      "user_viewable": true,
-      "user_editable": false,
-      "rules": [
-        "nullable",
-        "numeric"
-      ],
-      "sort": 14
-    },
-    {
-      "name": "[System] LD Library Path",
-      "description": "Required to load server libraries.",
-      "env_variable": "LD_LIBRARY_PATH",
-      "default_value": "./linux64",
-      "user_viewable": false,
-      "user_editable": false,
-      "rules": [
-        "required",
-        "string"
-      ],
-      "sort": 15
-    },
-    {
-      "name": "[System] Shutdown Command",
-      "description": "",
-      "env_variable": "STOP",
-      "default_value": "kill -2 $!; wait;",
-      "user_viewable": false,
-      "user_editable": false,
-      "rules": [
-        "required",
-        "string",
-        "max:20"
-      ],
-      "sort": 16
-    },
-    {
-      "name": "ModPack",
-      "description": "Enter the Dependency String name for a ModPack to automatically be installed\r\nNOTE: If the modpack Updates, you will need to update this variable with the new Dependency String. This is done to allow Old Versions to be used.\r\nCHANGING THIS REQUIRES A SERVER REINSTALL",
-      "env_variable": "V_MODPACK",
-      "default_value": "",
-      "user_viewable": true,
-      "user_editable": true,
-      "rules": [
-        "string",
-        "nullable"
-      ],
-      "sort": 17
-    },
-    {
-      "name": "Server Name",
-      "description": "Name that appears in server browser.",
-      "env_variable": "SERVER_NAME",
-      "default_value": "My Server",
-      "user_viewable": true,
-      "user_editable": true,
-      "rules": [
-        "required",
-        "string",
-        "max:60"
-      ],
-      "sort": 1
-    }
-  ]
+    "variables": [
+        {
+            "sort": 5,
+            "name": "Auto Update",
+            "description": "",
+            "env_variable": "AUTO_UPDATE",
+            "default_value": "1",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "required",
+                "boolean"
+            ]
+        },
+        {
+            "sort": 10,
+            "name": "Backup Count",
+            "description": "Sets how many automatic backups will be kept. The first is the 'short' backup length, and the rest are the 'long' backup length. When default values are used means one backup that is 2 hours old, and 3 backups that are 12 hours apart. Default: 4.",
+            "env_variable": "BACKUP_COUNT",
+            "default_value": "4",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "required",
+                "numeric",
+                "min:0"
+            ]
+        },
+        {
+            "sort": 9,
+            "name": "Backup Interval",
+            "description": "Change how often the world will save in seconds. Default: 1800 (30 minutes).",
+            "env_variable": "BACKUP_INTERVAL",
+            "default_value": "1800",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "required",
+                "numeric",
+                "min:0"
+            ]
+        },
+        {
+            "sort": 12,
+            "name": "Backup Longtime",
+            "description": "Sets the interval between the subsequent automatic backups in seconds. Default: 43200 (12 hours).",
+            "env_variable": "BACKUP_LONGTIME",
+            "default_value": "43200",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "required",
+                "numeric",
+                "min:0"
+            ]
+        },
+        {
+            "sort": 11,
+            "name": "Backup Shorttime",
+            "description": "Sets the interval between the first automatic backups in seconds. Default: 7200 (2 hours).",
+            "env_variable": "BACKUP_SHORTTIME",
+            "default_value": "7200",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "required",
+                "numeric",
+                "min:0"
+            ]
+        },
+        {
+            "sort": 13,
+            "name": "[System] Console Filter",
+            "description": "Remove unwanted outputs from the console.",
+            "env_variable": "CONSOLE_FILTER",
+            "default_value": "/^\\(Filename:.*Line:[[:space:]]+[[:digit:]]+\\)$/d; /^([[:space:]]+)?$/d",
+            "user_viewable": false,
+            "user_editable": false,
+            "rules": [
+                "string"
+            ]
+        },
+        {
+            "sort": 6,
+            "name": "Enable Crossplay",
+            "description": "Enable crossplay support",
+            "env_variable": "ENABLE_CROSSPLAY",
+            "default_value": "0",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "required",
+                "boolean"
+            ]
+        },
+        {
+            "sort": 15,
+            "name": "[System] LD Library Path",
+            "description": "Required to load server libraries.",
+            "env_variable": "LD_LIBRARY_PATH",
+            "default_value": "./linux64",
+            "user_viewable": false,
+            "user_editable": false,
+            "rules": [
+                "required",
+                "string"
+            ]
+        },
+        {
+            "sort": 2,
+            "name": "Server Password",
+            "description": "Server password.",
+            "env_variable": "PASSWORD",
+            "default_value": "secret",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "required",
+                "string",
+                "min:5",
+                "max:20"
+            ]
+        },
+        {
+            "sort": 4,
+            "name": "Public Server",
+            "description": "",
+            "env_variable": "PUBLIC_SERVER",
+            "default_value": "1",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "required",
+                "boolean"
+            ]
+        },
+        {
+            "sort": 1,
+            "name": "Server Name",
+            "description": "Name that appears in server browser.",
+            "env_variable": "SERVER_NAME",
+            "default_value": "My Server",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "required",
+                "string",
+                "max:60"
+            ]
+        },
+        {
+            "sort": 14,
+            "name": "[System] App ID",
+            "description": "Valheim steam app id for auto updates.",
+            "env_variable": "SRCDS_APPID",
+            "default_value": "896660",
+            "user_viewable": true,
+            "user_editable": false,
+            "rules": [
+                "nullable",
+                "numeric"
+            ]
+        },
+        {
+            "sort": 7,
+            "name": "Beta Branch",
+            "description": "",
+            "env_variable": "SRCDS_BETAID",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "max:30"
+            ]
+        },
+        {
+            "sort": 8,
+            "name": "Beta Password",
+            "description": "",
+            "env_variable": "SRCDS_BETAPASS",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "max:30"
+            ]
+        },
+        {
+            "sort": 16,
+            "name": "[System] Shutdown Command",
+            "description": "",
+            "env_variable": "STOP",
+            "default_value": "kill -2 $!; wait;",
+            "user_viewable": false,
+            "user_editable": false,
+            "rules": [
+                "required",
+                "string",
+                "max:20"
+            ]
+        },
+        {
+            "sort": 17,
+            "name": "ModPack",
+            "description": "Enter the Dependency String name for a ModPack to automatically be installed\r\nNOTE: If the modpack Updates, you will need to update this variable with the new Dependency String. This is done to allow Old Versions to be used.\r\nCHANGING THIS REQUIRES A SERVER REINSTALL",
+            "env_variable": "V_MODPACK",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "string",
+                "nullable"
+            ]
+        },
+        {
+            "sort": 3,
+            "name": "World Name",
+            "description": "Name to load if switching between multiple saved worlds.",
+            "env_variable": "WORLD",
+            "default_value": "Dedicated",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "required",
+                "string",
+                "max:20"
+            ]
+        }
+    ]
 }


### PR DESCRIPTION
Updated version and exported_at fields, modified startup command, and changed validation rules for several configuration options.

# Description

BepInEx was not loading at all with this egg, I had to change the startup command to match the start beinex server script to fix the issue.

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/pelican-eggs/games-steamcmd/blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [ ] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- If this is an egg update fill these out -->

* [x] You verify that the start command applied does not use a shell script
  * [ ] If some script is needed then it is part of a current yolk or a PR to add one
* [x] The egg was exported from the panel