### PR TITLE
Fix update_url for vanilla rust

### DIFF
--- a/rust/vanilla/egg-rust.yaml
+++ b/rust/vanilla/egg-rust.yaml
@@ -1,8 +1,8 @@
 _comment: 'DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL'
 meta:
   version: PLCN_v3
-  update_url: https://raw.githubusercontent.com/pelican-eggs/games-steamcmd/refs/heads/main/rust/vanilla/egg-rust.yaml'
-exported_at: '2025-10-31T12:25:32+00:00'
+  update_url: 'https://raw.githubusercontent.com/pelican-eggs/games-steamcmd/refs/heads/main/rust/vanilla/egg-rust.yaml'
+exported_at: '2026-02-20T08:29:15+00:00'
 name: Rust
 author: panel@example.com
 uuid: bace2dfb-209c-452a-9459-7d6f340b07ae


### PR DESCRIPTION
There was a missing `'`