### PR TITLE
Update Soulmask: Add map option to use new DLC

### DIFF
--- a/soulmask/egg-soulmask.json
+++ b/soulmask/egg-soulmask.json
@@ -1,144 +1,202 @@
 {
-    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
+    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
-        "version": "PTDL_v2",
+        "version": "PLCN_v3",
         "update_url": null
     },
-    "exported_at": "2024-06-01T13:27:43+02:00",
+    "exported_at": "2026-04-11T10:18:02+00:00",
     "name": "Soulmask",
     "author": "josdekurk@gmail.com",
+    "uuid": "2982661f-7141-4260-88e6-d31e157eeba8",
     "description": "Escaping a deadly sacrificial ritual, you find an ancient mystical mask on your journey. This mask holds potent knowledge, changing the world you knew. Face the harsh challenges of nature, survive, rally followers, and build your own tribe. Explore and unveil the truths behind the enigmatic mask.",
+    "image": null,
+    "tags": [],
     "features": [
         "steam_disk_space"
     ],
     "docker_images": {
-        "SteamCMD": "ghcr.io\/parkervcp\/steamcmd:debian"
+        "SteamCMD": "ghcr.io/parkervcp/steamcmd:debian"
     },
     "file_denylist": [],
-    "startup": "\/home\/container\/WS\/Binaries\/Linux\/WSServer-Linux-Shipping WS Level01_Main -server -SILENT -SteamServerName=\"{{SERVER_NAME}}\" -saving={{SAVE_TIME}} -Port={{SERVER_PORT}} -QueryPort={{QUERY_PORT}} -EchoPort={{ECHO_PORT}} -forcepassthrough -MaxPlayers={{MAX_PLAYERS}} -backup={{BACKUP_TIME}} -log -UTF8Output -MULTIHOME=0.0.0.0 {{EXTRA_ARGS}} -online=Steam -adminpsw={{ADMIN_PASSWORD}} -PSW={{SERVER_PASSWORD}}",
+    "startup_commands": {
+        "Default": "/home/container/WS/Binaries/Linux/WSServer-Linux-Shipping WS {{MAP}} -server -SILENT -SteamServerName=\"{{SERVER_NAME}}\" -saving={{SAVE_TIME}} -Port={{SERVER_PORT}} -QueryPort={{QUERY_PORT}} -EchoPort={{ECHO_PORT}} -forcepassthrough -MaxPlayers={{MAX_PLAYERS}} -backup={{BACKUP_TIME}} -log -UTF8Output -MULTIHOME=0.0.0.0 {{EXTRA_ARGS}} -online=Steam -adminpsw={{ADMIN_PASSWORD}} -PSW={{SERVER_PASSWORD}}"
+    },
     "config": {
         "files": "{}",
-        "startup": "{\r\n    \"done\": \"Create Dungeon Successed\"\r\n}",
+        "startup": "{\n    \"done\": \"Create Dungeon Successed\"\n}",
         "logs": "{}",
         "stop": "^C"
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/bash\r\n# steamcmd Base Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\n# Image to install with is 'ghcr.io\/parkervcp\/installers:debian'\r\n\r\n\r\n# Install packages. Default packages below are not required if using our existing install image thus speeding up the install process.\r\n#apt -y update\r\n#apt -y --no-install-recommends install curl lib32gcc-s1 ca-certificates\r\n\r\n## just in case someone removed the defaults.\r\nif [[ \"${STEAM_USER}\" == \"\" ]] || [[ \"${STEAM_PASS}\" == \"\" ]]; then\r\n    echo -e \"steam user is not set.\\n\"\r\n    echo -e \"Using anonymous user.\\n\"\r\n    STEAM_USER=anonymous\r\n    STEAM_PASS=\"\"\r\n    STEAM_AUTH=\"\"\r\nelse\r\n    echo -e \"user set to ${STEAM_USER}\"\r\nfi\r\n\r\n## download and install steamcmd\r\ncd \/tmp\r\nmkdir -p \/mnt\/server\/steamcmd\r\ncurl -sSL -o steamcmd.tar.gz https:\/\/steamcdn-a.akamaihd.net\/client\/installer\/steamcmd_linux.tar.gz\r\ntar -xzvf steamcmd.tar.gz -C \/mnt\/server\/steamcmd\r\nmkdir -p \/mnt\/server\/steamapps # Fix steamcmd disk write error when this folder is missing\r\ncd \/mnt\/server\/steamcmd\r\n\r\n# SteamCMD fails otherwise for some reason, even running as root.\r\n# This is changed at the end of the install process anyways.\r\nchown -R root:root \/mnt\r\nexport HOME=\/mnt\/server\r\n\r\n## install game using steamcmd\r\n.\/steamcmd.sh +force_install_dir \/mnt\/server +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} $( [[ \"${WINDOWS_INSTALL}\" == \"1\" ]] && printf %s '+@sSteamCmdForcePlatformType windows' ) +app_update ${SRCDS_APPID} +app_update 1007 $( [[ -z ${SRCDS_BETAID} ]] || printf %s \"-beta ${SRCDS_BETAID}\" ) $( [[ -z ${SRCDS_BETAPASS} ]] || printf %s \"-betapassword ${SRCDS_BETAPASS}\" ) ${INSTALL_FLAGS} validate +quit ## other flags may be needed depending on install. looking at you cs 1.6\r\n\r\n## set up 32 bit libraries\r\nmkdir -p \/mnt\/server\/.steam\/sdk32\r\ncp -v linux32\/steamclient.so ..\/.steam\/sdk32\/steamclient.so\r\n\r\n## set up 64 bit libraries\r\nmkdir -p \/mnt\/server\/.steam\/sdk64\r\ncp -v linux64\/steamclient.so ..\/.steam\/sdk64\/steamclient.so\r\n\r\n## add below your custom commands if needed\r\n## Maybe this path is just needed?\r\nmkdir -p \/mnt\/server\/WS\/Saved\/Config\/LinuxServer\r\n\r\n## install end\r\necho \"-----------------------------------------\"\r\necho \"Installation completed...\"\r\necho \"-----------------------------------------\"",
-            "container": "ghcr.io\/parkervcp\/installers:debian",
+            "script": "#!/bin/bash\r\n# steamcmd Base Installation Script\r\n#\r\n# Server Files: /mnt/server\r\n# Image to install with is 'ghcr.io/parkervcp/installers:debian'\r\n\r\n\r\n# Install packages. Default packages below are not required if using our existing install image thus speeding up the install process.\r\n#apt -y update\r\n#apt -y --no-install-recommends install curl lib32gcc-s1 ca-certificates\r\n\r\n## just in case someone removed the defaults.\r\nif [[ \"${STEAM_USER}\" == \"\" ]] || [[ \"${STEAM_PASS}\" == \"\" ]]; then\r\n    echo -e \"steam user is not set.\\n\"\r\n    echo -e \"Using anonymous user.\\n\"\r\n    STEAM_USER=anonymous\r\n    STEAM_PASS=\"\"\r\n    STEAM_AUTH=\"\"\r\nelse\r\n    echo -e \"user set to ${STEAM_USER}\"\r\nfi\r\n\r\n## download and install steamcmd\r\ncd /tmp\r\nmkdir -p /mnt/server/steamcmd\r\ncurl -sSL -o steamcmd.tar.gz https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz\r\ntar -xzvf steamcmd.tar.gz -C /mnt/server/steamcmd\r\nmkdir -p /mnt/server/steamapps # Fix steamcmd disk write error when this folder is missing\r\ncd /mnt/server/steamcmd\r\n\r\n# SteamCMD fails otherwise for some reason, even running as root.\r\n# This is changed at the end of the install process anyways.\r\nchown -R root:root /mnt\r\nexport HOME=/mnt/server\r\n\r\n## install game using steamcmd\r\n./steamcmd.sh +force_install_dir /mnt/server +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} $( [[ \"${WINDOWS_INSTALL}\" == \"1\" ]] && printf %s '+@sSteamCmdForcePlatformType windows' ) +app_update ${SRCDS_APPID} +app_update 1007 $( [[ -z ${SRCDS_BETAID} ]] || printf %s \"-beta ${SRCDS_BETAID}\" ) $( [[ -z ${SRCDS_BETAPASS} ]] || printf %s \"-betapassword ${SRCDS_BETAPASS}\" ) ${INSTALL_FLAGS} validate +quit ## other flags may be needed depending on install. looking at you cs 1.6\r\n\r\n## set up 32 bit libraries\r\nmkdir -p /mnt/server/.steam/sdk32\r\ncp -v linux32/steamclient.so ../.steam/sdk32/steamclient.so\r\n\r\n## set up 64 bit libraries\r\nmkdir -p /mnt/server/.steam/sdk64\r\ncp -v linux64/steamclient.so ../.steam/sdk64/steamclient.so\r\n\r\n## add below your custom commands if needed\r\n## Maybe this path is just needed?\r\nmkdir -p /mnt/server/WS/Saved/Config/LinuxServer\r\n\r\n## install end\r\necho \"-----------------------------------------\"\r\necho \"Installation completed...\"\r\necho \"-----------------------------------------\"",
+            "container": "ghcr.io/parkervcp/installers:debian",
             "entrypoint": "bash"
         }
     },
     "variables": [
         {
-            "name": "App ID",
-            "description": "",
-            "env_variable": "SRCDS_APPID",
-            "default_value": "3017300",
-            "user_viewable": false,
-            "user_editable": false,
-            "rules": "required|string|in:3017300",
-            "field_type": "text"
-        },
-        {
-            "name": "Auto Update",
-            "description": "Auto update the server on start",
-            "env_variable": "AUTO_UPDATE",
-            "default_value": "1",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": "boolean",
-            "field_type": "text"
-        },
-        {
-            "name": "Server Name",
-            "description": "Specifies the name of the game instance displayed in the server list",
-            "env_variable": "SERVER_NAME",
-            "default_value": "Soulmask Server",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": "required|string|max:85",
-            "field_type": "text"
-        },
-        {
-            "name": "Max Players",
-            "description": "Specifies the maximum number of players the game instance can support.",
-            "env_variable": "MAX_PLAYERS",
-            "default_value": "60",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": "required|numeric|between:1,70",
-            "field_type": "text"
-        },
-        {
-            "name": "Backup Interval",
-            "description": "Specifies the interval for writing the game database to disk (unit: seconds).",
-            "env_variable": "BACKUP_TIME",
-            "default_value": "960",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": "required|numeric",
-            "field_type": "text"
-        },
-        {
-            "name": "Save Time Interval",
-            "description": "Specifies the interval for writing game objects to the database (unit: seconds).",
-            "env_variable": "SAVE_TIME",
-            "default_value": "600",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": "required|numeric",
-            "field_type": "text"
-        },
-        {
-            "name": "Query Port",
-            "description": "Specifies the Steam query port, UDP, needs to be open to the public.",
-            "env_variable": "QUERY_PORT",
-            "default_value": "27015",
-            "user_viewable": true,
-            "user_editable": false,
-            "rules": "required|numeric|between:1024,65536",
-            "field_type": "text"
-        },
-        {
-            "name": "Maintenance Port",
-            "description": "Maintenance port, used for local telnet server maintenance, TCP, does not need to be open.",
-            "env_variable": "ECHO_PORT",
-            "default_value": "18888",
-            "user_viewable": true,
-            "user_editable": false,
-            "rules": "required|numeric|between:1024,65536",
-            "field_type": "text"
-        },
-        {
-            "name": "Server Password",
-            "description": "Server password, private servers can specify a password, players must enter the password to enter the server.",
-            "env_variable": "SERVER_PASSWORD",
-            "default_value": "",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": "nullable|string|max:32",
-            "field_type": "text"
-        },
-        {
+            "sort": 10,
             "name": "Admin Password",
             "description": "GM activation password.Open GM Panel (gm key [password])",
             "env_variable": "ADMIN_PASSWORD",
             "default_value": "",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "nullable|string|max:32",
-            "field_type": "text"
+            "rules": [
+                "nullable",
+                "string",
+                "max:32"
+            ]
         },
         {
+            "sort": 2,
+            "name": "Auto Update",
+            "description": "Auto update the server on start",
+            "env_variable": "AUTO_UPDATE",
+            "default_value": "1",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "boolean"
+            ]
+        },
+        {
+            "sort": 5,
+            "name": "Backup Interval",
+            "description": "Specifies the interval for writing the game database to disk (unit: seconds).",
+            "env_variable": "BACKUP_TIME",
+            "default_value": "960",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "required",
+                "numeric"
+            ]
+        },
+        {
+            "sort": 8,
+            "name": "Maintenance Port",
+            "description": "Maintenance port, used for local telnet server maintenance, TCP, does not need to be open.",
+            "env_variable": "ECHO_PORT",
+            "default_value": "18888",
+            "user_viewable": true,
+            "user_editable": false,
+            "rules": [
+                "required",
+                "numeric",
+                "between:1024,65536"
+            ]
+        },
+        {
+            "sort": 11,
             "name": "Extra Arguments",
             "description": "Additional arguments passed on startup such as: -pve or -pve",
             "env_variable": "EXTRA_ARGS",
             "default_value": "",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "nullable|string|max:32",
-            "field_type": "text"
+            "rules": [
+                "nullable",
+                "string",
+                "max:32"
+            ]
+        },
+        {
+            "sort": 12,
+            "name": "Map",
+            "description": "You need the DLC \"Soulmask: Shifting Sands\" for the map DLC_Level01_Main",
+            "env_variable": "MAP",
+            "default_value": "Level01_Main",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "required",
+                "in:Level01_Main,DLC_Level01_Main"
+            ]
+        },
+        {
+            "sort": 4,
+            "name": "Max Players",
+            "description": "Specifies the maximum number of players the game instance can support.",
+            "env_variable": "MAX_PLAYERS",
+            "default_value": "60",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "required",
+                "numeric",
+                "between:1,70"
+            ]
+        },
+        {
+            "sort": 7,
+            "name": "Query Port",
+            "description": "Specifies the Steam query port, UDP, needs to be open to the public.",
+            "env_variable": "QUERY_PORT",
+            "default_value": "27015",
+            "user_viewable": true,
+            "user_editable": false,
+            "rules": [
+                "required",
+                "numeric",
+                "between:1024,65536"
+            ]
+        },
+        {
+            "sort": 6,
+            "name": "Save Time Interval",
+            "description": "Specifies the interval for writing game objects to the database (unit: seconds).",
+            "env_variable": "SAVE_TIME",
+            "default_value": "600",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "required",
+                "numeric"
+            ]
+        },
+        {
+            "sort": 3,
+            "name": "Server Name",
+            "description": "Specifies the name of the game instance displayed in the server list",
+            "env_variable": "SERVER_NAME",
+            "default_value": "Soulmask Server",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "required",
+                "string",
+                "max:85"
+            ]
+        },
+        {
+            "sort": 9,
+            "name": "Server Password",
+            "description": "Server password, private servers can specify a password, players must enter the password to enter the server.",
+            "env_variable": "SERVER_PASSWORD",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "nullable",
+                "string",
+                "max:32"
+            ]
+        },
+        {
+            "sort": 1,
+            "name": "App ID",
+            "description": "",
+            "env_variable": "SRCDS_APPID",
+            "default_value": "3017300",
+            "user_viewable": false,
+            "user_editable": false,
+            "rules": [
+                "required",
+                "string",
+                "in:3017300"
+            ]
         }
     ]
 }


### PR DESCRIPTION
# Description
The game received a new DLC on April 10 featuring a new map. To play this map, an existing setting must be changed.
To ensure that both the main game and the DLC can be played, I have added a new field that allows you to select which map to use.

During testing, I found that the save file for one map is not overwritten or deleted when playing the other map; instead, a separate save file is created.

Since I don't use Pterodactyl but only Pelican, I didn't modify the `egg-pterodactyl-soulmask.json` file, as I can't verify whether the changes would work.

Game: [Steam Shop](https://store.steampowered.com/app/2646460/Soulmask/) [SteamDB](https://steamdb.info/app/2646460/)
DLC: [Steam Shop](https://store.steampowered.com/app/3966020/Soulmask_Shifting_Sands/) [SteamDB](https://steamdb.info/app/3966020/)


<!-- Please explain what is being changed or added as a short overview for this PR. Also, link existing relevant issues if they exist with resolves # -->

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/pelican-eggs/games-steamcmd/blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- If this is an egg update fill these out -->

* [x] You verify that the start command applied does not use a shell script
  * [ ] If some script is needed then it is part of a current yolk or a PR to add one
* [x] The egg was exported from the panel