### PR TITLE
Windrose Egg Added

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@
   * [Plus Mod](valheim/valheim_plus)
 * [VEIN](vein)
 * [Voyagers of Nera](voyagers_of_nera)
+* [Windrose](windrose)
 * [Wreckfest](wreckfest)
 * [Wurm Unlimited](wurm_unlimited/)
 * [Zombie Survival Game Online](zombie_survival_game_online/)

--- a/windrose/README.md
+++ b/windrose/README.md
@@ -1,0 +1,48 @@
+# Windrose
+
+### Authors / Maintainers
+
+- [Styxbleich](https://github.com/Styxbleich)
+
+## Description
+
+Windrose is an Early Access PvE co-op pirate survival game built on Unreal Engine 5. The dedicated server binary is Windows-only and runs via Proton on Linux. Installed anonymously via SteamCMD (App ID `4129620`).
+
+> **Important:** Players connect using an **invite code**, NOT by IP:port. After the server is marked running in the console, share the `InviteCode` with your crew via **Play → Connect to Server → paste code**.
+
+## Features
+
+- Configurable server name, invite code, max players, and optional password
+- Auto-update via SteamCMD on startup (toggleable)
+- World progress saved automatically via RocksDB and persists between restarts
+- Full server log streamed to the Pelican console
+
+## Server Ports
+
+| Port | Default | Protocol | Note |
+|------|---------|----------|------|
+| Game | 7777 | UDP | Must be set as Primary Allocation |
+| Query | 7778 | UDP | Must be added as an Additional Allocation |
+
+> Windrose uses P2P NAT punch-through for player connections. These ports do not need to be forwarded for players to connect, but **both must be allocated in Pelican** or the server will fail to register with the Windrose relay servers.
+
+## Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| Server Name | `Windrose1` | Display name shown in `ServerDescription.json` |
+| Invite Code | `Server01` | Code players use to connect. Min 6 chars, alphanumeric. |
+| Max Players | `4` | Max simultaneous players (1–8). Developers recommend 4 or fewer during Early Access. |
+| Password Protected | `false` | Set to `true` to require a password to join. |
+| Server Password | *(blank)* | Only used if Password Protected is `true`. |
+| Update on Start | `1` | Set to `1` to check for updates on every start, `0` to skip. |
+
+## Notes
+
+- World saves are stored at `R5/Saved/SaveProfiles/Default/RocksDB/` — SSD storage is strongly recommended.
+- Xalia-related errors in the console on startup are harmless and do not affect server operation.
+- This is an Early Access title. Stability may vary between game updates.
+
+## Developer Dedicated Server Guide
+
+The Developers have also published a guide for using a dedicated server found here (https://playwindrose.com/dedicated-server-guide/#wsg-setup)

--- a/windrose/egg-windrose.json
+++ b/windrose/egg-windrose.json
@@ -1,0 +1,140 @@
+{
+    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
+    "meta": {
+        "version": "PLCN_v3",
+        "update_url": null
+    },
+    "exported_at": "2026-04-22T05:47:33+00:00",
+    "name": "Windrose",
+    "author": "Styxbleich@users.noreply.github.com",
+    "uuid": "c73ba020-1a8d-4913-a7ad-95d439d92953",
+    "description": "Windrose Dedicated Server (Early Access) PvE co-op pirate survival on Unreal Engine 5. The dedicated server binary is Windows-only and runs via Proton on Linux. Files are installed anonymously via SteamCMD (App ID 4129620).\nPlayers connect using an invite code shown in the server console, NOT by IP:port. After startup, share the InviteCode with your crew: Play Connect to Server paste code. 12 GB (4-player).\nSSD storage strongly recommended (server uses RocksDB for world saves).",
+    "image": null,
+    "tags": [
+        "steam_disk_space"
+    ],
+    "features": [
+        "steam_disk_space"
+    ],
+    "docker_images": {
+        "ghcr.io/parkervcp/steamcmd:proton": "ghcr.io/parkervcp/steamcmd:proton"
+    },
+    "file_denylist": [],
+    "startup_commands": {
+        "Default": "python3 /home/container/patch_config.py && rm -f /home/container/R5/Saved/Logs/R5.log && PROTON_DISABLE_XALIA=1 proton run /home/container/R5/Binaries/Win64/WindroseServer-Win64-Shipping.exe -log -MULTIHOME=0.0.0.0 -PORT=7777 -QUERYPORT=7778 & PID=$! ; tail -c0 -F /home/container/R5/Saved/Logs/R5.log --pid=$PID"
+    },
+    "config": {
+        "files": "{}",
+        "startup": "{\"done\": \"Server Connection Info\"}",
+        "logs": "{}",
+        "stop": "^C"
+    },
+    "scripts": {
+        "installation": {
+            "script": "#!/bin/bash\r\n# Windrose Dedicated Server \u2014 Pelican Install Script\r\n# Author: Styxbleich\r\n# Based on parkervcp/pelican-eggs SteamCMD Wine pattern\r\n#\r\n# Server Files: /mnt/server\r\n# Install image: ghcr.io/parkervcp/installers:debian\r\n\r\n## Set Steam credentials \u2014 anonymous for Windrose\r\nif [[ \"${STEAM_USER}\" == \"\" ]] || [[ \"${STEAM_PASS}\" == \"\" ]]; then\r\n    echo -e \"Steam user not set \u2014 using anonymous login.\"\r\n    STEAM_USER=anonymous\r\n    STEAM_PASS=\"\"\r\n    STEAM_AUTH=\"\"\r\nelse\r\n    echo -e \"Steam user: ${STEAM_USER}\"\r\nfi\r\n\r\n## Download and install SteamCMD\r\ncd /tmp\r\nmkdir -p /mnt/server/steamcmd\r\ncurl -sSL -o steamcmd.tar.gz https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz\r\ntar -xzvf steamcmd.tar.gz -C /mnt/server/steamcmd\r\n\r\nmkdir -p /mnt/server/steamapps\r\ncd /mnt/server/steamcmd\r\n\r\n# SteamCMD requires root ownership and HOME set\r\nchown -R root:root /mnt\r\nexport HOME=/mnt/server\r\n\r\n## Install Windrose Dedicated Server\r\n## +@sSteamCmdForcePlatformType windows is critical \u2014\r\n## tells SteamCMD to pull the Windows binary (no Linux build exists)\r\n./steamcmd.sh \\\r\n  +force_install_dir /mnt/server \\\r\n  +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} \\\r\n  +@sSteamCmdForcePlatformType windows \\\r\n  +app_update 4129620 validate \\\r\n  +quit\r\n\r\n## Set up Steam SDK libraries\r\nmkdir -p /mnt/server/.steam/sdk32\r\ncp -v linux32/steamclient.so /mnt/server/.steam/sdk32/steamclient.so\r\n\r\nmkdir -p /mnt/server/.steam/sdk64\r\ncp -v linux64/steamclient.so /mnt/server/.steam/sdk64/steamclient.so\r\n\r\n## Write default ServerDescription.json if not present\r\nCONFIG_FILE=\"/mnt/server/R5/ServerDescription.json\"\r\nmkdir -p /mnt/server/R5\r\n\r\nif [ ! -f \"${CONFIG_FILE}\" ]; then\r\n  echo \"[Windrose] Writing default ServerDescription.json...\"\r\n\r\n  cat > \"${CONFIG_FILE}\" << 'JSEOF'\r\n{\r\n  \"Version\": 1,\r\n  \"ServerDescription_Persistent\": {\r\n    \"PersistentServerId\": \"\",\r\n    \"InviteCode\": \"server01\",\r\n    \"IsPasswordProtected\": false,\r\n    \"Password\": \"\",\r\n    \"ServerName\": \"Windrose Server\",\r\n    \"WorldIslandId\": \"\",\r\n    \"MaxPlayerCount\": 4,\r\n    \"P2pProxyAddress\": \"127.0.0.1\"\r\n  }\r\n}\r\nJSEOF\r\nfi\r\n\r\n## Write config patcher script\r\necho \"[Windrose] Writing config patcher...\"\r\n\r\ncat > /mnt/server/patch_config.py << 'PYEOF'\r\nimport json\r\nimport os\r\nimport sys\r\n\r\ncfg = \"/home/container/R5/ServerDescription.json\"\r\n\r\ntry:\r\n    with open(cfg) as f:\r\n        d = json.load(f)\r\nexcept Exception as e:\r\n    print(f\"[Windrose] Could not read config: {e}\", file=sys.stderr)\r\n    sys.exit(0)\r\n\r\np = d.setdefault(\"ServerDescription_Persistent\", {})\r\n\r\nif os.environ.get(\"INVITE_CODE\"):\r\n    p[\"InviteCode\"] = os.environ[\"INVITE_CODE\"]\r\n\r\nif os.environ.get(\"SERVER_NAME\"):\r\n    p[\"ServerName\"] = os.environ[\"SERVER_NAME\"]\r\n\r\nif os.environ.get(\"MAX_PLAYERS\"):\r\n    try:\r\n        p[\"MaxPlayerCount\"] = int(os.environ[\"MAX_PLAYERS\"])\r\n    except ValueError:\r\n        pass\r\n\r\nif os.environ.get(\"IS_PASSWORD_PROTECTED\"):\r\n    p[\"IsPasswordProtected\"] = os.environ[\"IS_PASSWORD_PROTECTED\"].lower() == \"true\"\r\n\r\nif os.environ.get(\"SERVER_PASSWORD\") is not None:\r\n    p[\"Password\"] = os.environ.get(\"SERVER_PASSWORD\", \"\")\r\n\r\nwith open(cfg, \"w\") as f:\r\n    json.dump(d, f, indent=2)\r\n\r\nprint(\r\n    f\"[Windrose] Config patched \u2014 \"\r\n    f\"InviteCode={p.get('InviteCode','?')} \"\r\n    f\"Name={p.get('ServerName','?')} \"\r\n    f\"Players={p.get('MaxPlayerCount','?')} \"\r\n    f\"Password={p.get('IsPasswordProtected', False)}\"\r\n)\r\nPYEOF\r\n\r\nchmod +x /mnt/server/patch_config.py\r\n\r\n## Verify install\r\nif [ -f \"/mnt/server/R5/Binaries/Win64/WindroseServer-Win64-Shipping.exe\" ]; then\r\n  echo \"-----------------------------------------\"\r\n  echo \"Windrose install complete!\"\r\n  echo \"App ID 4129620 | anonymous | Windows binary\"\r\n  echo \"-----------------------------------------\"\r\nelse\r\n  echo \"-----------------------------------------\"\r\n  echo \"WARNING: WindroseServer-Win64-Shipping.exe not found.\"\r\n  echo \"SteamCMD may have failed. Try reinstalling.\"\r\n  echo \"-----------------------------------------\"\r\n  exit 1\r\nfi",
+            "container": "ghcr.io/parkervcp/installers:debian",
+            "entrypoint": "bash"
+        }
+    },
+    "variables": [
+        {
+            "sort": 2,
+            "name": "Invite Code",
+            "description": "Code players paste to connect. Min 6 chars, alphanumeric, case sensitive.",
+            "env_variable": "INVITE_CODE",
+            "default_value": "Server01",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "required",
+                "string",
+                "min:6",
+                "max:32",
+                "alpha_num"
+            ]
+        },
+        {
+            "sort": 4,
+            "name": "Password Protected",
+            "description": "Set to true to require a password to join, false for open access.",
+            "env_variable": "IS_PASSWORD_PROTECTED",
+            "default_value": "false",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "required",
+                "in:true,false"
+            ]
+        },
+        {
+            "sort": 3,
+            "name": "Max Players",
+            "description": "Max simultaneous players. Developers recommend 4 or fewer for Early Access stability.",
+            "env_variable": "MAX_PLAYERS",
+            "default_value": "4",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "required",
+                "integer",
+                "min:1",
+                "max:8"
+            ]
+        },
+        {
+            "sort": 1,
+            "name": "Server Name",
+            "description": "The display name of your server shown in ServerDescription.json",
+            "env_variable": "SERVER_NAME",
+            "default_value": "Windrose1",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "required",
+                "string",
+                "max:64"
+            ]
+        },
+        {
+            "sort": 5,
+            "name": "Server Password",
+            "description": "Password to join the server. Only used if Password Protected is true.",
+            "env_variable": "SERVER_PASSWORD",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "nullable",
+                "string",
+                "max:64"
+            ]
+        },
+        {
+            "sort": 7,
+            "name": "Steam App ID",
+            "description": "App ID for Windrose Dedicated Server",
+            "env_variable": "SRCDS_APPID",
+            "default_value": "4129620",
+            "user_viewable": true,
+            "user_editable": false,
+            "rules": [
+                "required",
+                "numeric",
+                "in:4129620"
+            ]
+        },
+        {
+            "sort": 6,
+            "name": "Update on Start",
+            "description": "Set to 1 to check for updates via SteamCMD on every start. Set to 0 to skip.",
+            "env_variable": "UPDATE_ON_START",
+            "default_value": "1",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": [
+                "required",
+                "in:0,1"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
# Description

A working egg for Windrose has been added. The egg has been tested for the following: boot, invite code patching, log streaming, player connection.

This gets the server up and running and allows users to connect. It appears at the current moment, the server auto selects region, but this will get updated as time goes on. It appears that there is a way to force a region. 

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/pelican-eggs/games-steamcmd/blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- If this is an egg update fill these out -->

* [x] You verify that the start command applied does not use a shell script
  * [x] If some script is needed then it is part of a current yolk or a PR to add one
* [x] The egg was exported from the panel

<!-- You can erase the new egg submission template if you're not adding a completely new egg -->

## New egg Submissions

1. [x] Does your submission pass tests (server is connectable)?
2. [ ] Does your egg use a custom docker image?
    * [ ] Have you tried to use a generic image?
    * [ ] Did you PR the necessary changes to make it work?
3. [x] Have you added the egg to the main README.md and any other README files in subdirectories of the egg (e.g /game_eggs) according to the alphabetical order?
4. [x] Have you added a unique README.md for the egg you are adding according to the alphabetical order?
5. [x] You verify that the start command applied does not use a shell script
    * [x] If some script is needed then it is part of a current yolk or a PR to add one
6. [x] The egg was exported from the panel