### PR TITLE
Add The Ship: Murder Party egg (Windows server under Wine)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@
 * [The Isle](the_isle)
   * [Evrima](the_isle/evrima)
 * [The Front](thefront)
+* [The Ship: Murder Party](the_ship)
 * [Tower Unite](tower_unite)
 * [Truck Simulator](truck-simulator)
   * [American Truck Simulator](truck-simulator/american-truck-simulator)

--- a/the_ship/README.md
+++ b/the_ship/README.md
@@ -1,0 +1,41 @@
+# The Ship: Murder Party
+
+## From their [Steam Store page](https://store.steampowered.com/app/2400/The_Ship_Murder_Party/)
+
+The Ship is a multiplayer murder-mystery game built on the Source engine. Each player is given 
+a Quarry to kill – and must evade their own Hunter in the process, all set on board a series 
+of 1920s art deco cruise ships.
+
+### Server Ports
+
+The Ship requires a single game port. It can be changed to any other.
+
+| Port | default |
+|------|---------|
+| Game | 27015   |
+
+## Steam Download [SteamStore](https://store.steampowered.com/app/2400/The_Ship_Murder_Party/)
+
+## Notes
+
+- **Runs the Windows server under Wine.** The Ship's native Linux dedicated server is broken
+  on modern systems: it crashes during map load:
+  - `The futex facility returned an unexpected error code` abort on glibc >= 2.34)
+  - or some unexplained memory corruption if ran with a lower glibc version
+- Console is driven over RCON. The server is started with  `+log on +logaddress_add 127.0.0.1:27500`, 
+  which makes Source forward every log event over UDP the instant it happens. A tiny listener 
+  (`udplog.py`, written by the install script) prints those events to the panel console, 
+  so logs appear live. The startup command then attaches a persistent RCON terminal.
+- A licensed Steam account is required.
+
+### Variables
+
+| Variable        | Description                                                        |
+|-----------------|--------------------------------------------------------------------|
+| `STEAM_USER`    | Steam account that owns The Ship (anonymous is refused).           |
+| `STEAM_PASS`    | Password for that account.                                         |
+| `STEAM_AUTH`    | Steam Guard code, if one is somehow required. Normally left blank. |
+| `RCON_PASSWORD` | Password for the panel console (RCON). Set this to something secret. |
+| `SRCDS_MAP`     | Default map, e.g. `batavier`, `atalanta`, `huronian`.              |
+| `MAX_PLAYERS`   | Maximum player slots (1-32).                                       |
+| `AUTO_UPDATE`   | Update the server files on each (re)start.                         |

--- a/the_ship/README.md
+++ b/the_ship/README.md
@@ -22,10 +22,8 @@ The Ship requires a single game port. It can be changed to any other.
   on modern systems: it crashes during map load:
   - `The futex facility returned an unexpected error code` abort on glibc >= 2.34)
   - or some unexplained memory corruption if ran with a lower glibc version
-- Console is driven over RCON. The server is started with  `+log on +logaddress_add 127.0.0.1:27500`, 
-  which makes Source forward every log event over UDP the instant it happens. A tiny listener 
-  (`udplog.py`, written by the install script) prints those events to the panel console, 
-  so logs appear live. The startup command then attaches a persistent RCON terminal.
+- You cannot issue commands over the panel, but you can still view logs, since scrds over wine
+  has compatibility issues.
 - A licensed Steam account is required.
 
 ### Variables
@@ -35,7 +33,6 @@ The Ship requires a single game port. It can be changed to any other.
 | `STEAM_USER`    | Steam account that owns The Ship (anonymous is refused).           |
 | `STEAM_PASS`    | Password for that account.                                         |
 | `STEAM_AUTH`    | Steam Guard code, if one is somehow required. Normally left blank. |
-| `RCON_PASSWORD` | Password for the panel console (RCON). Set this to something secret. |
 | `SRCDS_MAP`     | Default map, e.g. `batavier`, `atalanta`, `huronian`.              |
 | `MAX_PLAYERS`   | Maximum player slots (1-32).                                       |
 | `AUTO_UPDATE`   | Update the server files on each (re)start.                         |

--- a/the_ship/README.md
+++ b/the_ship/README.md
@@ -14,17 +14,14 @@ The Ship requires a single game port. It can be changed to any other.
 |------|---------|
 | Game | 27015   |
 
-## Steam Download [SteamStore](https://store.steampowered.com/app/2400/The_Ship_Murder_Party/)
-
 ## Notes
 
 - **Runs the Windows server under Wine.** The Ship's native Linux dedicated server is broken
   on modern systems: it crashes during map load:
   - `The futex facility returned an unexpected error code` abort on glibc >= 2.34)
   - or some unexplained memory corruption if ran with a lower glibc version
-- You cannot issue commands over the panel, but you can still view logs, since scrds over wine
-  has compatibility issues.
-- A licensed Steam account is required.
+- You cannot issue commands via the console due to the server being wrapped under Wine, but you can still view logs.
+- A Steam account that owns the game is required to download the server.
 
 ### Variables
 

--- a/the_ship/egg-pterodactyl-the-ship.json
+++ b/the_ship/egg-pterodactyl-the-ship.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2026-06-30T22:28:42+02:00",
+    "exported_at": "2026-07-02T22:01:05+02:00",
     "name": "The Ship: Murder Party",
     "author": "noreply@zyiks.eu",
     "description": "The Ship: Murder Party dedicated server. The native Linux server is broken on modern systems, so this runs the Windows dedicated server under Wine. Requires a licensed Steam account (anonymous is refused).",
@@ -57,7 +57,7 @@
             "default_value": "",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "nullable|string",
+            "rules": "required|string",
             "field_type": "text"
         },
         {
@@ -67,7 +67,7 @@
             "default_value": "",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "nullable|string",
+            "rules": "required|string",
             "field_type": "text"
         },
         {
@@ -87,7 +87,7 @@
             "default_value": "batavier",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "nullable|string",
+            "rules": "required|string",
             "field_type": "text"
         },
         {

--- a/the_ship/egg-the-ship.json
+++ b/the_ship/egg-the-ship.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2026-06-30T20:39:14+02:00",
+    "exported_at": "2026-06-30T22:28:42+02:00",
     "name": "The Ship: Murder Party",
     "author": "noreply@zyiks.eu",
     "description": "The Ship: Murder Party dedicated server. The native Linux server is broken on modern systems, so this runs the Windows dedicated server under Wine. Requires a licensed Steam account (anonymous is refused).",
@@ -15,7 +15,7 @@
         "ghcr.io\/parkervcp\/yolks:wine_latest": "ghcr.io\/parkervcp\/yolks:wine_latest"
     },
     "file_denylist": [],
-    "startup": "python3 -u \/home\/container\/udplog.py 27500 & NCPID=$!; grep -q rcon_password \/home\/container\/ship\/cfg\/server.cfg 2>\/dev\/null || echo \"rcon_password \\\"{{RCON_PASSWORD}}\\\"\" >> \/home\/container\/ship\/cfg\/server.cfg; wine srcds.exe -console +log on +logaddress_add 127.0.0.1:27500 +rcon_password \"{{RCON_PASSWORD}}\" -game ship -port {{SERVER_PORT}} +map {{SRCDS_MAP}} +maxplayers {{MAX_PLAYERS}} +ip 0.0.0.0 -strictportbind & SRVPID=$!; until rcon -a 127.0.0.1:{{SERVER_PORT}} -p \"{{RCON_PASSWORD}}\" \"echo ready\" <\/dev\/null >\/dev\/null 2>&1; do kill -0 $SRVPID 2>\/dev\/null || { kill $NCPID 2>\/dev\/null; exit; }; sleep 3; done; rcon -a 127.0.0.1:{{SERVER_PORT}} -p \"{{RCON_PASSWORD}}\"; kill $NCPID 2>\/dev\/null",
+    "startup": "wine srcds.exe -console -condebug -conclearlog -game ship +log on +map {{SRCDS_MAP}} +maxplayers {{MAX_PLAYERS}} -port {{SERVER_PORT}} +ip 0.0.0.0 -strictportbind & SRVPID=$!; tail -c0 -F \/home\/container\/ship\/console.log --pid=$SRVPID",
     "config": {
         "files": "{}",
         "startup": "{\n    \"done\": \"Started map\"\n}",
@@ -24,7 +24,7 @@
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/bash\n# The Ship: Murder Party - Windows-server-under-Wine install script\n#\n# Server Files: \/mnt\/server\n# Install image: ghcr.io\/parkervcp\/installers:debian\n#\n# The Ship's NATIVE LINUX dedicated server is broken on modern systems (heap\n# corruption -> crashes during map load, \"futex facility\" abort on new glibc),\n# so this egg installs and runs the WINDOWS dedicated server under Wine instead.\n#\n# Vars: STEAM_USER, STEAM_PASS, STEAM_AUTH (licensed account that OWNS The Ship -\n#       anonymous returns \"No subscription\"), SRCDS_APPID=2403, INSTALL_FLAGS.\n\nif [[ \"${STEAM_USER}\" == \"\" ]] || [[ \"${STEAM_PASS}\" == \"\" ]]; then\n    echo -e \"steam user is not set.\\n\"\n    echo -e \"Using anonymous user (note: app 2403 requires a licensed account).\\n\"\n    STEAM_USER=anonymous\n    STEAM_PASS=\"\"\n    STEAM_AUTH=\"\"\nelse\n    echo -e \"user set to ${STEAM_USER}\"\nfi\n\ncd \/tmp\nmkdir -p \/mnt\/server\/steamcmd\ncurl -sSL -o steamcmd.tar.gz https:\/\/steamcdn-a.akamaihd.net\/client\/installer\/steamcmd_linux.tar.gz\ntar -xzvf steamcmd.tar.gz -C \/mnt\/server\/steamcmd\nmkdir -p \/mnt\/server\/steamapps # fix steamcmd disk write error when this folder is missing\ncd \/mnt\/server\/steamcmd\n\nchown -R root:root \/mnt\nexport HOME=\/mnt\/server\n\n## Force the WINDOWS platform - the native Linux build of The Ship is non-functional.\n.\/steamcmd.sh +force_install_dir \/mnt\/server +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} $( [[ \"${WINDOWS_INSTALL}\" == \"1\" ]] && printf %s '+@sSteamCmdForcePlatformType windows' ) +app_update ${SRCDS_APPID} ${INSTALL_FLAGS} validate +quit\n\n## steam client libraries (used by steamcmd; harmless for the wine runtime)\nmkdir -p \/mnt\/server\/.steam\/sdk32\ncp -v linux32\/steamclient.so ..\/.steam\/sdk32\/steamclient.so 2>\/dev\/null || true\nmkdir -p \/mnt\/server\/.steam\/sdk64\ncp -v linux64\/steamclient.so ..\/.steam\/sdk64\/steamclient.so 2>\/dev\/null || true\n\n## UDP log listener: Source forwards live log events via UDP (logaddress); this prints\n## them to the console (Wine block-buffers srcds stdout, so the UDP path is what streams live).\ncat > \/mnt\/server\/udplog.py <<'PYEOF'\nimport socket, sys\nport = int(sys.argv[1]) if len(sys.argv) > 1 else 27500\ns = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)\ns.bind((\"127.0.0.1\", port))\nwhile True:\n    data, _ = s.recvfrom(4096)\n    line = bytes(b for b in data if 9 <= b < 127 or b == 10).decode(\"ascii\", \"replace\")\n    sys.stdout.write(line.rstrip(\"\\n\") + \"\\n\")\n    sys.stdout.flush()\nPYEOF\n\necho \"-----------------------------------------\"\necho \"Installation completed...\"\necho \"-----------------------------------------\"\n",
+            "script": "#!\/bin\/bash\n# The Ship dedicated server install. Runs the Windows server under Wine, the native Linux build is broken.\n\n## just in case someone removed the defaults.\nif [[ \"${STEAM_USER}\" == \"\" ]] || [[ \"${STEAM_PASS}\" == \"\" ]]; then\n    echo -e \"steam user is not set.\\n\"\n    echo -e \"Using anonymous user (app 2403 needs a licensed account though).\\n\"\n    STEAM_USER=anonymous\n    STEAM_PASS=\"\"\n    STEAM_AUTH=\"\"\nelse\n    echo -e \"user set to ${STEAM_USER}\"\nfi\n\n## download and install steamcmd\ncd \/tmp\nmkdir -p \/mnt\/server\/steamcmd\ncurl -sSL -o steamcmd.tar.gz https:\/\/steamcdn-a.akamaihd.net\/client\/installer\/steamcmd_linux.tar.gz\ntar -xzvf steamcmd.tar.gz -C \/mnt\/server\/steamcmd\nmkdir -p \/mnt\/server\/steamapps # Fix steamcmd disk write error when this folder is missing\ncd \/mnt\/server\/steamcmd\n\nchown -R root:root \/mnt\nexport HOME=\/mnt\/server\n\n## install game using steamcmd, forcing the windows platform\n.\/steamcmd.sh +force_install_dir \/mnt\/server +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} $( [[ \"${WINDOWS_INSTALL}\" == \"1\" ]] && printf %s '+@sSteamCmdForcePlatformType windows' ) +app_update ${SRCDS_APPID} ${INSTALL_FLAGS} validate +quit\n\n## set up steam client libraries\nmkdir -p \/mnt\/server\/.steam\/sdk32\ncp -v linux32\/steamclient.so ..\/.steam\/sdk32\/steamclient.so 2>\/dev\/null || true\nmkdir -p \/mnt\/server\/.steam\/sdk64\ncp -v linux64\/steamclient.so ..\/.steam\/sdk64\/steamclient.so 2>\/dev\/null || true\n\necho \"install complete\"\n",
             "container": "ghcr.io\/parkervcp\/installers:debian",
             "entrypoint": "\/bin\/bash"
         }
@@ -78,16 +78,6 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": "nullable|string",
-            "field_type": "text"
-        },
-        {
-            "name": "RCON password",
-            "description": "Password for sending console commands from the panel via RCON. Set this to something secret.",
-            "env_variable": "RCON_PASSWORD",
-            "default_value": "changeme",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": "required|string|max:64",
             "field_type": "text"
         },
         {

--- a/the_ship/egg-the-ship.json
+++ b/the_ship/egg-the-ship.json
@@ -1,134 +1,124 @@
 {
-  "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
-  "meta": {
-    "version": "PTDL_v2",
-    "update_url": null
-  },
-  "exported_at": "2026-06-29T23:36:34+02:00",
-  "name": "The Ship: Murder Party",
-  "author": "noreply@zyiks.eu",
-  "description": "The Ship: Murder Party dedicated server. The native Linux server is broken on modern systems, so this runs the Windows dedicated server under Wine. Requires a licensed Steam account (anonymous is refused).",
-  "features": [
-    "steam_disk_space"
-  ],
-  "docker_images": {
-    "ghcr.io/parkervcp/yolks:wine_latest": "ghcr.io/parkervcp/yolks:wine_latest"
-  },
-  "file_denylist": [],
-  "startup": "python3 -u /home/container/udplog.py 27500 & NCPID=$!; grep -q rcon_password /home/container/ship/cfg/server.cfg 2>/dev/null || echo \"rcon_password \\\"{{RCON_PASSWORD}}\\\"\" >> /home/container/ship/cfg/server.cfg; wine srcds.exe -console +log on +logaddress_add 127.0.0.1:27500 +rcon_password \"{{RCON_PASSWORD}}\" -game ship -port {{SERVER_PORT}} +map {{SRCDS_MAP}} +maxplayers {{MAX_PLAYERS}} +ip 0.0.0.0 -strictportbind & SRVPID=$!; until rcon -a 127.0.0.1:{{SERVER_PORT}} -p \"{{RCON_PASSWORD}}\" \"echo ready\" </dev/null >/dev/null 2>&1; do kill -0 $SRVPID 2>/dev/null || { kill $NCPID 2>/dev/null; exit; }; sleep 3; done; rcon -a 127.0.0.1:{{SERVER_PORT}} -p \"{{RCON_PASSWORD}}\"; kill $NCPID 2>/dev/null",
-  "config": {
-    "files": "{}",
-    "startup": "{\n    \"done\": \"Started map\"\n}",
-    "logs": "{}",
-    "stop": "^C"
-  },
-  "scripts": {
-    "installation": {
-      "script": "#!/bin/bash\n# The Ship: Murder Party - Windows-server-under-Wine install script\n#\n# Server Files: /mnt/server\n# Install image: ghcr.io/parkervcp/installers:debian\n#\n# The Ship's NATIVE LINUX dedicated server is broken on modern systems (heap\n# corruption -> crashes during map load, \"futex facility\" abort on new glibc),\n# so this egg installs and runs the WINDOWS dedicated server under Wine instead.\n#\n# Vars: STEAM_USER, STEAM_PASS, STEAM_AUTH (licensed account that OWNS The Ship -\n#       anonymous returns \"No subscription\"), SRCDS_APPID=2403, INSTALL_FLAGS.\n\nif [[ \"${STEAM_USER}\" == \"\" ]] || [[ \"${STEAM_PASS}\" == \"\" ]]; then\n    echo -e \"steam user is not set.\\n\"\n    echo -e \"Using anonymous user (note: app 2403 requires a licensed account).\\n\"\n    STEAM_USER=anonymous\n    STEAM_PASS=\"\"\n    STEAM_AUTH=\"\"\nelse\n    echo -e \"user set to ${STEAM_USER}\"\nfi\n\ncd /tmp\nmkdir -p /mnt/server/steamcmd\ncurl -sSL -o steamcmd.tar.gz https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz\ntar -xzvf steamcmd.tar.gz -C /mnt/server/steamcmd\nmkdir -p /mnt/server/steamapps # fix steamcmd disk write error when this folder is missing\ncd /mnt/server/steamcmd\n\nchown -R root:root /mnt\nexport HOME=/mnt/server\n\n## Force the WINDOWS platform - the native Linux build of The Ship is non-functional.\n./steamcmd.sh +force_install_dir /mnt/server +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} $( [[ \"${WINDOWS_INSTALL}\" == \"1\" ]] && printf %s '+@sSteamCmdForcePlatformType windows' ) +app_update ${SRCDS_APPID} ${INSTALL_FLAGS} validate +quit\n\n## steam client libraries (used by steamcmd; harmless for the wine runtime)\nmkdir -p /mnt/server/.steam/sdk32\ncp -v linux32/steamclient.so ../.steam/sdk32/steamclient.so 2>/dev/null || true\nmkdir -p /mnt/server/.steam/sdk64\ncp -v linux64/steamclient.so ../.steam/sdk64/steamclient.so 2>/dev/null || true\n\n## UDP log listener: Source forwards live log events via UDP (logaddress); this prints\n## them to the console (Wine block-buffers srcds stdout, so the UDP path is what streams live).\ncat > /mnt/server/udplog.py <<'PYEOF'\nimport socket, sys\nport = int(sys.argv[1]) if len(sys.argv) > 1 else 27500\ns = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)\ns.bind((\"127.0.0.1\", port))\nwhile True:\n    data, _ = s.recvfrom(4096)\n    line = bytes(b for b in data if 9 <= b < 127 or b == 10).decode(\"ascii\", \"replace\")\n    sys.stdout.write(line.rstrip(\"\\n\") + \"\\n\")\n    sys.stdout.flush()\nPYEOF\n\necho \"-----------------------------------------\"\necho \"Installation completed...\"\necho \"-----------------------------------------\"\n",
-      "container": "ghcr.io/parkervcp/installers:debian",
-      "entrypoint": "/bin/bash"
-    }
-  },
-  "variables": [
-    {
-      "name": "Auto-update server",
-      "description": "Enable / disable auto-updating the server on restart.",
-      "env_variable": "AUTO_UPDATE",
-      "default_value": "1",
-      "user_viewable": true,
-      "user_editable": true,
-      "rules": "boolean",
-      "field_type": "text"
+    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
+    "meta": {
+        "version": "PTDL_v2",
+        "update_url": null
     },
-    {
-      "name": "Wine architecture",
-      "description": "Forces a 32-bit Wine prefix. The Ship's srcds.exe is 32-bit and will not run in a 64-bit prefix. Do not change.",
-      "env_variable": "WINEARCH",
-      "default_value": "win32",
-      "user_viewable": false,
-      "user_editable": false,
-      "rules": "required|string|in:win32",
-      "field_type": "text"
+    "exported_at": "2026-06-30T20:39:14+02:00",
+    "name": "The Ship: Murder Party",
+    "author": "noreply@zyiks.eu",
+    "description": "The Ship: Murder Party dedicated server. The native Linux server is broken on modern systems, so this runs the Windows dedicated server under Wine. Requires a licensed Steam account (anonymous is refused).",
+    "features": [
+        "steam_disk_space"
+    ],
+    "docker_images": {
+        "ghcr.io\/parkervcp\/yolks:wine_latest": "ghcr.io\/parkervcp\/yolks:wine_latest"
     },
-    {
-      "name": "Windows install",
-      "description": "Forces SteamCMD to install/update the Windows server files (run under Wine). Do not change - the native Linux server is broken.",
-      "env_variable": "WINDOWS_INSTALL",
-      "default_value": "1",
-      "user_viewable": false,
-      "user_editable": false,
-      "rules": "required|string|in:1",
-      "field_type": "text"
+    "file_denylist": [],
+    "startup": "python3 -u \/home\/container\/udplog.py 27500 & NCPID=$!; grep -q rcon_password \/home\/container\/ship\/cfg\/server.cfg 2>\/dev\/null || echo \"rcon_password \\\"{{RCON_PASSWORD}}\\\"\" >> \/home\/container\/ship\/cfg\/server.cfg; wine srcds.exe -console +log on +logaddress_add 127.0.0.1:27500 +rcon_password \"{{RCON_PASSWORD}}\" -game ship -port {{SERVER_PORT}} +map {{SRCDS_MAP}} +maxplayers {{MAX_PLAYERS}} +ip 0.0.0.0 -strictportbind & SRVPID=$!; until rcon -a 127.0.0.1:{{SERVER_PORT}} -p \"{{RCON_PASSWORD}}\" \"echo ready\" <\/dev\/null >\/dev\/null 2>&1; do kill -0 $SRVPID 2>\/dev\/null || { kill $NCPID 2>\/dev\/null; exit; }; sleep 3; done; rcon -a 127.0.0.1:{{SERVER_PORT}} -p \"{{RCON_PASSWORD}}\"; kill $NCPID 2>\/dev\/null",
+    "config": {
+        "files": "{}",
+        "startup": "{\n    \"done\": \"Started map\"\n}",
+        "logs": "{}",
+        "stop": "^C"
     },
-    {
-      "name": "Steam User",
-      "description": "Steam account that OWNS The Ship. Anonymous is refused (No subscription).",
-      "env_variable": "STEAM_USER",
-      "default_value": "",
-      "user_viewable": true,
-      "user_editable": true,
-      "rules": "nullable|string",
-      "field_type": "text"
+    "scripts": {
+        "installation": {
+            "script": "#!\/bin\/bash\n# The Ship: Murder Party - Windows-server-under-Wine install script\n#\n# Server Files: \/mnt\/server\n# Install image: ghcr.io\/parkervcp\/installers:debian\n#\n# The Ship's NATIVE LINUX dedicated server is broken on modern systems (heap\n# corruption -> crashes during map load, \"futex facility\" abort on new glibc),\n# so this egg installs and runs the WINDOWS dedicated server under Wine instead.\n#\n# Vars: STEAM_USER, STEAM_PASS, STEAM_AUTH (licensed account that OWNS The Ship -\n#       anonymous returns \"No subscription\"), SRCDS_APPID=2403, INSTALL_FLAGS.\n\nif [[ \"${STEAM_USER}\" == \"\" ]] || [[ \"${STEAM_PASS}\" == \"\" ]]; then\n    echo -e \"steam user is not set.\\n\"\n    echo -e \"Using anonymous user (note: app 2403 requires a licensed account).\\n\"\n    STEAM_USER=anonymous\n    STEAM_PASS=\"\"\n    STEAM_AUTH=\"\"\nelse\n    echo -e \"user set to ${STEAM_USER}\"\nfi\n\ncd \/tmp\nmkdir -p \/mnt\/server\/steamcmd\ncurl -sSL -o steamcmd.tar.gz https:\/\/steamcdn-a.akamaihd.net\/client\/installer\/steamcmd_linux.tar.gz\ntar -xzvf steamcmd.tar.gz -C \/mnt\/server\/steamcmd\nmkdir -p \/mnt\/server\/steamapps # fix steamcmd disk write error when this folder is missing\ncd \/mnt\/server\/steamcmd\n\nchown -R root:root \/mnt\nexport HOME=\/mnt\/server\n\n## Force the WINDOWS platform - the native Linux build of The Ship is non-functional.\n.\/steamcmd.sh +force_install_dir \/mnt\/server +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} $( [[ \"${WINDOWS_INSTALL}\" == \"1\" ]] && printf %s '+@sSteamCmdForcePlatformType windows' ) +app_update ${SRCDS_APPID} ${INSTALL_FLAGS} validate +quit\n\n## steam client libraries (used by steamcmd; harmless for the wine runtime)\nmkdir -p \/mnt\/server\/.steam\/sdk32\ncp -v linux32\/steamclient.so ..\/.steam\/sdk32\/steamclient.so 2>\/dev\/null || true\nmkdir -p \/mnt\/server\/.steam\/sdk64\ncp -v linux64\/steamclient.so ..\/.steam\/sdk64\/steamclient.so 2>\/dev\/null || true\n\n## UDP log listener: Source forwards live log events via UDP (logaddress); this prints\n## them to the console (Wine block-buffers srcds stdout, so the UDP path is what streams live).\ncat > \/mnt\/server\/udplog.py <<'PYEOF'\nimport socket, sys\nport = int(sys.argv[1]) if len(sys.argv) > 1 else 27500\ns = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)\ns.bind((\"127.0.0.1\", port))\nwhile True:\n    data, _ = s.recvfrom(4096)\n    line = bytes(b for b in data if 9 <= b < 127 or b == 10).decode(\"ascii\", \"replace\")\n    sys.stdout.write(line.rstrip(\"\\n\") + \"\\n\")\n    sys.stdout.flush()\nPYEOF\n\necho \"-----------------------------------------\"\necho \"Installation completed...\"\necho \"-----------------------------------------\"\n",
+            "container": "ghcr.io\/parkervcp\/installers:debian",
+            "entrypoint": "\/bin\/bash"
+        }
     },
-    {
-      "name": "Steam Password",
-      "description": "Password for the Steam account. Steam Guard must be OFF (headless SteamCMD cannot complete email Guard).",
-      "env_variable": "STEAM_PASS",
-      "default_value": "",
-      "user_viewable": true,
-      "user_editable": true,
-      "rules": "nullable|string",
-      "field_type": "text"
-    },
-    {
-      "name": "Steam Auth (Guard code)",
-      "description": "Steam Guard code if required. Normally left blank with Guard off.",
-      "env_variable": "STEAM_AUTH",
-      "default_value": "",
-      "user_viewable": true,
-      "user_editable": true,
-      "rules": "nullable|string",
-      "field_type": "text"
-    },
-    {
-      "name": "RCON password",
-      "description": "Password for sending console commands from the panel via RCON. Set this to something secret.",
-      "env_variable": "RCON_PASSWORD",
-      "default_value": "changeme",
-      "user_viewable": true,
-      "user_editable": true,
-      "rules": "required|string|max:64",
-      "field_type": "text"
-    },
-    {
-      "name": "Map",
-      "description": "Default map to load on start (e.g. batavier, atalanta, huronian).",
-      "env_variable": "SRCDS_MAP",
-      "default_value": "batavier",
-      "user_viewable": true,
-      "user_editable": true,
-      "rules": "nullable|string",
-      "field_type": "text"
-    },
-    {
-      "name": "Max Players",
-      "description": "Maximum player slots.",
-      "env_variable": "MAX_PLAYERS",
-      "default_value": "8",
-      "user_viewable": true,
-      "user_editable": true,
-      "rules": "required|integer|between:1,32",
-      "field_type": "text"
-    },
-    {
-      "name": "App ID",
-      "description": "Steam app id for The Ship Dedicated Server. Do not modify.",
-      "env_variable": "SRCDS_APPID",
-      "default_value": "2403",
-      "user_viewable": false,
-      "user_editable": false,
-      "rules": "required|string|in:2403",
-      "field_type": "text"
-    }
-  ]
+    "variables": [
+        {
+            "name": "Auto-update server",
+            "description": "Enable \/ disable auto-updating the server on restart.",
+            "env_variable": "AUTO_UPDATE",
+            "default_value": "1",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "boolean",
+            "field_type": "text"
+        },
+        {
+            "name": "Windows install",
+            "description": "Forces SteamCMD to install\/update the Windows server files (run under Wine). Do not change - the native Linux server is broken.",
+            "env_variable": "WINDOWS_INSTALL",
+            "default_value": "1",
+            "user_viewable": false,
+            "user_editable": false,
+            "rules": "required|string|in:1",
+            "field_type": "text"
+        },
+        {
+            "name": "Steam User",
+            "description": "Steam account that OWNS The Ship. Anonymous is refused (No subscription).",
+            "env_variable": "STEAM_USER",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "nullable|string",
+            "field_type": "text"
+        },
+        {
+            "name": "Steam Password",
+            "description": "Password for the Steam account. Steam Guard must be OFF (headless SteamCMD cannot complete email Guard).",
+            "env_variable": "STEAM_PASS",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "nullable|string",
+            "field_type": "text"
+        },
+        {
+            "name": "Steam Auth (Guard code)",
+            "description": "Steam Guard code if required. Normally left blank with Guard off.",
+            "env_variable": "STEAM_AUTH",
+            "default_value": "",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "nullable|string",
+            "field_type": "text"
+        },
+        {
+            "name": "RCON password",
+            "description": "Password for sending console commands from the panel via RCON. Set this to something secret.",
+            "env_variable": "RCON_PASSWORD",
+            "default_value": "changeme",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string|max:64",
+            "field_type": "text"
+        },
+        {
+            "name": "Map",
+            "description": "Default map to load on start (e.g. batavier, atalanta, huronian).",
+            "env_variable": "SRCDS_MAP",
+            "default_value": "batavier",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "nullable|string",
+            "field_type": "text"
+        },
+        {
+            "name": "Max Players",
+            "description": "Maximum player slots.",
+            "env_variable": "MAX_PLAYERS",
+            "default_value": "8",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|integer|between:1,32",
+            "field_type": "text"
+        },
+        {
+            "name": "App ID",
+            "description": "Steam app id for The Ship Dedicated Server. Do not modify.",
+            "env_variable": "SRCDS_APPID",
+            "default_value": "2403",
+            "user_viewable": false,
+            "user_editable": false,
+            "rules": "required|string|in:2403",
+            "field_type": "text"
+        }
+    ]
 }

--- a/the_ship/egg-the-ship.json
+++ b/the_ship/egg-the-ship.json
@@ -1,0 +1,134 @@
+{
+  "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
+  "meta": {
+    "version": "PTDL_v2",
+    "update_url": null
+  },
+  "exported_at": "2026-06-29T23:36:34+02:00",
+  "name": "The Ship: Murder Party",
+  "author": "noreply@zyiks.eu",
+  "description": "The Ship: Murder Party dedicated server. The native Linux server is broken on modern systems, so this runs the Windows dedicated server under Wine. Requires a licensed Steam account (anonymous is refused).",
+  "features": [
+    "steam_disk_space"
+  ],
+  "docker_images": {
+    "ghcr.io/parkervcp/yolks:wine_latest": "ghcr.io/parkervcp/yolks:wine_latest"
+  },
+  "file_denylist": [],
+  "startup": "python3 -u /home/container/udplog.py 27500 & NCPID=$!; grep -q rcon_password /home/container/ship/cfg/server.cfg 2>/dev/null || echo \"rcon_password \\\"{{RCON_PASSWORD}}\\\"\" >> /home/container/ship/cfg/server.cfg; wine srcds.exe -console +log on +logaddress_add 127.0.0.1:27500 +rcon_password \"{{RCON_PASSWORD}}\" -game ship -port {{SERVER_PORT}} +map {{SRCDS_MAP}} +maxplayers {{MAX_PLAYERS}} +ip 0.0.0.0 -strictportbind & SRVPID=$!; until rcon -a 127.0.0.1:{{SERVER_PORT}} -p \"{{RCON_PASSWORD}}\" \"echo ready\" </dev/null >/dev/null 2>&1; do kill -0 $SRVPID 2>/dev/null || { kill $NCPID 2>/dev/null; exit; }; sleep 3; done; rcon -a 127.0.0.1:{{SERVER_PORT}} -p \"{{RCON_PASSWORD}}\"; kill $NCPID 2>/dev/null",
+  "config": {
+    "files": "{}",
+    "startup": "{\n    \"done\": \"Started map\"\n}",
+    "logs": "{}",
+    "stop": "^C"
+  },
+  "scripts": {
+    "installation": {
+      "script": "#!/bin/bash\n# The Ship: Murder Party - Windows-server-under-Wine install script\n#\n# Server Files: /mnt/server\n# Install image: ghcr.io/parkervcp/installers:debian\n#\n# The Ship's NATIVE LINUX dedicated server is broken on modern systems (heap\n# corruption -> crashes during map load, \"futex facility\" abort on new glibc),\n# so this egg installs and runs the WINDOWS dedicated server under Wine instead.\n#\n# Vars: STEAM_USER, STEAM_PASS, STEAM_AUTH (licensed account that OWNS The Ship -\n#       anonymous returns \"No subscription\"), SRCDS_APPID=2403, INSTALL_FLAGS.\n\nif [[ \"${STEAM_USER}\" == \"\" ]] || [[ \"${STEAM_PASS}\" == \"\" ]]; then\n    echo -e \"steam user is not set.\\n\"\n    echo -e \"Using anonymous user (note: app 2403 requires a licensed account).\\n\"\n    STEAM_USER=anonymous\n    STEAM_PASS=\"\"\n    STEAM_AUTH=\"\"\nelse\n    echo -e \"user set to ${STEAM_USER}\"\nfi\n\ncd /tmp\nmkdir -p /mnt/server/steamcmd\ncurl -sSL -o steamcmd.tar.gz https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz\ntar -xzvf steamcmd.tar.gz -C /mnt/server/steamcmd\nmkdir -p /mnt/server/steamapps # fix steamcmd disk write error when this folder is missing\ncd /mnt/server/steamcmd\n\nchown -R root:root /mnt\nexport HOME=/mnt/server\n\n## Force the WINDOWS platform - the native Linux build of The Ship is non-functional.\n./steamcmd.sh +force_install_dir /mnt/server +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} $( [[ \"${WINDOWS_INSTALL}\" == \"1\" ]] && printf %s '+@sSteamCmdForcePlatformType windows' ) +app_update ${SRCDS_APPID} ${INSTALL_FLAGS} validate +quit\n\n## steam client libraries (used by steamcmd; harmless for the wine runtime)\nmkdir -p /mnt/server/.steam/sdk32\ncp -v linux32/steamclient.so ../.steam/sdk32/steamclient.so 2>/dev/null || true\nmkdir -p /mnt/server/.steam/sdk64\ncp -v linux64/steamclient.so ../.steam/sdk64/steamclient.so 2>/dev/null || true\n\n## UDP log listener: Source forwards live log events via UDP (logaddress); this prints\n## them to the console (Wine block-buffers srcds stdout, so the UDP path is what streams live).\ncat > /mnt/server/udplog.py <<'PYEOF'\nimport socket, sys\nport = int(sys.argv[1]) if len(sys.argv) > 1 else 27500\ns = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)\ns.bind((\"127.0.0.1\", port))\nwhile True:\n    data, _ = s.recvfrom(4096)\n    line = bytes(b for b in data if 9 <= b < 127 or b == 10).decode(\"ascii\", \"replace\")\n    sys.stdout.write(line.rstrip(\"\\n\") + \"\\n\")\n    sys.stdout.flush()\nPYEOF\n\necho \"-----------------------------------------\"\necho \"Installation completed...\"\necho \"-----------------------------------------\"\n",
+      "container": "ghcr.io/parkervcp/installers:debian",
+      "entrypoint": "/bin/bash"
+    }
+  },
+  "variables": [
+    {
+      "name": "Auto-update server",
+      "description": "Enable / disable auto-updating the server on restart.",
+      "env_variable": "AUTO_UPDATE",
+      "default_value": "1",
+      "user_viewable": true,
+      "user_editable": true,
+      "rules": "boolean",
+      "field_type": "text"
+    },
+    {
+      "name": "Wine architecture",
+      "description": "Forces a 32-bit Wine prefix. The Ship's srcds.exe is 32-bit and will not run in a 64-bit prefix. Do not change.",
+      "env_variable": "WINEARCH",
+      "default_value": "win32",
+      "user_viewable": false,
+      "user_editable": false,
+      "rules": "required|string|in:win32",
+      "field_type": "text"
+    },
+    {
+      "name": "Windows install",
+      "description": "Forces SteamCMD to install/update the Windows server files (run under Wine). Do not change - the native Linux server is broken.",
+      "env_variable": "WINDOWS_INSTALL",
+      "default_value": "1",
+      "user_viewable": false,
+      "user_editable": false,
+      "rules": "required|string|in:1",
+      "field_type": "text"
+    },
+    {
+      "name": "Steam User",
+      "description": "Steam account that OWNS The Ship. Anonymous is refused (No subscription).",
+      "env_variable": "STEAM_USER",
+      "default_value": "",
+      "user_viewable": true,
+      "user_editable": true,
+      "rules": "nullable|string",
+      "field_type": "text"
+    },
+    {
+      "name": "Steam Password",
+      "description": "Password for the Steam account. Steam Guard must be OFF (headless SteamCMD cannot complete email Guard).",
+      "env_variable": "STEAM_PASS",
+      "default_value": "",
+      "user_viewable": true,
+      "user_editable": true,
+      "rules": "nullable|string",
+      "field_type": "text"
+    },
+    {
+      "name": "Steam Auth (Guard code)",
+      "description": "Steam Guard code if required. Normally left blank with Guard off.",
+      "env_variable": "STEAM_AUTH",
+      "default_value": "",
+      "user_viewable": true,
+      "user_editable": true,
+      "rules": "nullable|string",
+      "field_type": "text"
+    },
+    {
+      "name": "RCON password",
+      "description": "Password for sending console commands from the panel via RCON. Set this to something secret.",
+      "env_variable": "RCON_PASSWORD",
+      "default_value": "changeme",
+      "user_viewable": true,
+      "user_editable": true,
+      "rules": "required|string|max:64",
+      "field_type": "text"
+    },
+    {
+      "name": "Map",
+      "description": "Default map to load on start (e.g. batavier, atalanta, huronian).",
+      "env_variable": "SRCDS_MAP",
+      "default_value": "batavier",
+      "user_viewable": true,
+      "user_editable": true,
+      "rules": "nullable|string",
+      "field_type": "text"
+    },
+    {
+      "name": "Max Players",
+      "description": "Maximum player slots.",
+      "env_variable": "MAX_PLAYERS",
+      "default_value": "8",
+      "user_viewable": true,
+      "user_editable": true,
+      "rules": "required|integer|between:1,32",
+      "field_type": "text"
+    },
+    {
+      "name": "App ID",
+      "description": "Steam app id for The Ship Dedicated Server. Do not modify.",
+      "env_variable": "SRCDS_APPID",
+      "default_value": "2403",
+      "user_viewable": false,
+      "user_editable": false,
+      "rules": "required|string|in:2403",
+      "field_type": "text"
+    }
+  ]
+}

--- a/the_ship/egg-the-ship.yaml
+++ b/the_ship/egg-the-ship.yaml
@@ -1,0 +1,148 @@
+_comment: 'DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL'
+meta:
+  version: PLCN_v3
+  update_url: https://raw.githubusercontent.com/pelican-eggs/games-steamcmd/refs/heads/main/the_ship/egg-the-ship.yaml
+exported_at: '2026-07-02T22:01:05+02:00'
+name: 'The Ship: Murder Party'
+author: noreply@zyiks.eu
+uuid: 18113094-8f05-4657-9eff-ab1e86b2f1bb
+description: 'The Ship: Murder Party dedicated server. The native Linux server is broken on modern systems, so this runs the Windows dedicated server under Wine. Requires a licensed Steam account (anonymous is refused).'
+icon: null
+tags:
+  - steamcmd
+features:
+  - steam_disk_space
+docker_images:
+  ghcr.io/parkervcp/yolks:wine_latest: ghcr.io/parkervcp/yolks:wine_latest
+file_denylist: []
+startup_commands:
+  Default: wine srcds.exe -console -condebug -conclearlog -game ship +log on +map {{SRCDS_MAP}} +maxplayers {{MAX_PLAYERS}} -port {{SERVER_PORT}} +ip 0.0.0.0 -strictportbind & SRVPID=$!; tail -c0 -F /home/container/ship/console.log --pid=$SRVPID
+config:
+  files: {}
+  startup:
+    done: Started map
+  logs: {}
+  stop: ^C
+scripts:
+  installation:
+    script: |
+      #!/bin/bash
+      # The Ship dedicated server install. Runs the Windows server under Wine, the native Linux build is broken.
+
+      ## just in case someone removed the defaults.
+      if [[ "${STEAM_USER}" == "" ]] || [[ "${STEAM_PASS}" == "" ]]; then
+          echo -e "steam user is not set.\n"
+          echo -e "Using anonymous user (app 2403 needs a licensed account though).\n"
+          STEAM_USER=anonymous
+          STEAM_PASS=""
+          STEAM_AUTH=""
+      else
+          echo -e "user set to ${STEAM_USER}"
+      fi
+
+      ## download and install steamcmd
+      cd /tmp
+      mkdir -p /mnt/server/steamcmd
+      curl -sSL -o steamcmd.tar.gz https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz
+      tar -xzvf steamcmd.tar.gz -C /mnt/server/steamcmd
+      mkdir -p /mnt/server/steamapps # Fix steamcmd disk write error when this folder is missing
+      cd /mnt/server/steamcmd
+
+      chown -R root:root /mnt
+      export HOME=/mnt/server
+
+      ## install game using steamcmd, forcing the windows platform
+      ./steamcmd.sh +force_install_dir /mnt/server +login ${STEAM_USER} ${STEAM_PASS} ${STEAM_AUTH} $( [[ "${WINDOWS_INSTALL}" == "1" ]] && printf %s '+@sSteamCmdForcePlatformType windows' ) +app_update ${SRCDS_APPID} ${INSTALL_FLAGS} validate +quit
+
+      ## set up steam client libraries
+      mkdir -p /mnt/server/.steam/sdk32
+      cp -v linux32/steamclient.so ../.steam/sdk32/steamclient.so 2>/dev/null || true
+      mkdir -p /mnt/server/.steam/sdk64
+      cp -v linux64/steamclient.so ../.steam/sdk64/steamclient.so 2>/dev/null || true
+
+      echo "install complete"
+    container: ghcr.io/parkervcp/installers:debian
+    entrypoint: /bin/bash
+variables:
+  - name: Auto-update server
+    description: Enable / disable auto-updating the server on restart.
+    env_variable: AUTO_UPDATE
+    default_value: '1'
+    user_viewable: true
+    user_editable: true
+    rules:
+      - boolean
+    sort: 1
+  - name: Windows install
+    description: Forces SteamCMD to install/update the Windows server files (run under Wine). Do not change - the native Linux server is broken.
+    env_variable: WINDOWS_INSTALL
+    default_value: '1'
+    user_viewable: false
+    user_editable: false
+    rules:
+      - required
+      - string
+      - in:1
+    sort: 2
+  - name: Steam User
+    description: Steam account that OWNS The Ship. Anonymous is refused (No subscription).
+    env_variable: STEAM_USER
+    default_value: ''
+    user_viewable: true
+    user_editable: true
+    rules:
+      - required
+      - string
+    sort: 3
+  - name: Steam Password
+    description: Password for the Steam account. Steam Guard must be OFF (headless SteamCMD cannot complete email Guard).
+    env_variable: STEAM_PASS
+    default_value: ''
+    user_viewable: true
+    user_editable: true
+    rules:
+      - required
+      - string
+    sort: 4
+  - name: Steam Auth (Guard code)
+    description: Steam Guard code if required. Normally left blank with Guard off.
+    env_variable: STEAM_AUTH
+    default_value: ''
+    user_viewable: true
+    user_editable: true
+    rules:
+      - nullable
+      - string
+    sort: 5
+  - name: Map
+    description: Default map to load on start (e.g. batavier, atalanta, huronian).
+    env_variable: SRCDS_MAP
+    default_value: batavier
+    user_viewable: true
+    user_editable: true
+    rules:
+      - required
+      - string
+    sort: 6
+  - name: Max Players
+    description: Maximum player slots.
+    env_variable: MAX_PLAYERS
+    default_value: '8'
+    user_viewable: true
+    user_editable: true
+    rules:
+      - required
+      - integer
+      - between:1,32
+    sort: 7
+  - name: App ID
+    description: Steam app id for The Ship Dedicated Server. Do not modify.
+    env_variable: SRCDS_APPID
+    default_value: '2403'
+    user_viewable: false
+    user_editable: false
+    rules:
+      - required
+      - string
+      - in:2403
+    sort: 8


### PR DESCRIPTION
# Description

Adds a new egg for **The Ship: Murder Party** (Source engine, Steam app `2403`). Resolves #33.

The Ship's native Linux dedicated server is broken, as it crashes during map load. This egg therefore installs and runs the  Windows dedicated server under Wine, which is stable. It uses the stock `ghcr.io/parkervcp/yolks:wine_latest` image.

## Checklist for all submissions

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/pelican-eggs/games-steamcmd/blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

## New egg Submissions

1. [x] Does your submission pass tests (server is connectable)?
2. [ ] Does your egg use a custom docker image?
    * [x] Have you tried to use a generic image?
    * [ ] Did you PR the necessary changes to make it work?
3. [x] Have you added the egg to the main README.md and any other README files in subdirectories of the egg (e.g /game_eggs) according to the alphabetical order?
4. [x] Have you added a unique README.md for the egg you are adding according to the alphabetical order?
5. [x] You verify that the start command applied does not use a shell script
    * [x] If some script is needed then it is part of a current yolk or a PR to add one
6. [x] The egg was exported from the panel