### PR TITLE
Update egg-abiotic-factor.json

### DIFF
--- a/abiotic_factor/egg-abiotic-factor.json
+++ b/abiotic_factor/egg-abiotic-factor.json
@@ -17,11 +17,11 @@
         "steam_disk_space"
     ],
     "docker_images": {
-        "Steamcmd Proton": "ghcr.io/pelican-eggs/steamcmd:proton"
+        "Wine": "ghcr.io/pelican-eggs/yolks:wine_latest"
     },
     "file_denylist": [],
     "startup_commands": {
-        "Default": "cd /home/container/AbioticFactor/Binaries/Win64; proton run ./AbioticFactorServer-Win64-Shipping.exe -log -useperfthreads -NoAsyncLoadingThread -MaxServerPlayers={{NUM_PLAYERS}} -Port={{SERVER_PORT}} -QueryPort={{QUERY_PORT}} -ServerPassword=\"{{SERVER_PASSWORD}}\" -SteamServerName=\"{{SERVER_NAME}}\" -SandboxIniPath=\"{{SANDBOX_INI_PATH}}\" & AF_PID=$!; tail -c0 -F /home/container/AbioticFactor/Saved/Logs/AbioticFactor.log --pid=$AF_PID"
+        "Default": "cd /home/container/AbioticFactor/Binaries/Win64; wine ./AbioticFactorServer-Win64-Shipping.exe -log -useperfthreads -NoAsyncLoadingThread -MaxServerPlayers={{NUM_PLAYERS}} -Port={{SERVER_PORT}} -QueryPort={{QUERY_PORT}} -ServerPassword=\"{{SERVER_PASSWORD}}\" -SteamServerName=\"{{SERVER_NAME}}\" -SandboxIniPath=\"{{SANDBOX_INI_PATH}}\" & AF_PID=$!; tail -c0 -F /home/container/AbioticFactor/Saved/Logs/AbioticFactor.log --pid=$AF_PID"
     },
     "config": {
         "files": "{}",


### PR DESCRIPTION
# Description

**What:** Swaps the egg's Docker image to `ghcr.io/pelican-eggs/yolks:wine_latest` and changes `proton run` to `wine` in the startup command. Two-line diff, nothing else touched.

**Why:** Under the Proton image the server can hang silently during engine init. The log just stops after the last plugin mount (`Mounting Engine plugin WorldMetrics`), the process stays alive with no crash or error, and the panel sits at "Starting" forever. Happens every time for me, including on fresh installs. I burned an evening on environment tuning and none of it helped: raised nofile ulimits, vm.max_map_count, PROTON_NO_ESYNC/FSYNC, WINE_CPU_TOPOLOGY, unrestricted cpuset, `-onethread`, removing `-useperfthreads`. The same install boots in about a second under Wine. Heads up that `wine64` no longer exists in Wine 11+, so the command has to be `wine`.

**Tested:** Pelican v1.0.0-beta35, Wings v1.0.0-beta26, Docker inside an unprivileged Proxmox LXC (i9-13900H). Default host tuning, 6144MB/200%/20480MB limits, fresh install from this exact egg with no overrides. Boots, Steam registration succeeds ("Session creation completed"), external joins verified.

If you'd rather keep Proton available as a second `docker_images` entry I can do that instead, but note the single startup command would only be correct for the Wine selection.